### PR TITLE
Fix Heroku's Procfile to work for static sites

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 public/
+web: bin/boot


### PR DESCRIPTION
Switching from PHP's buildpack to the static site buildpack broke. This should fix the error.