### PR TITLE
Add link to GitHub on Compare/Reference pages

### DIFF
--- a/web/templates/compare.html
+++ b/web/templates/compare.html
@@ -4,7 +4,7 @@
 {% block content %}
         <div class="container">
             <div class="row mt-5">
-                <h2 class="col-12">Comparing {{ lang1 }}'s and {{ lang2 }}'s {{ concept }}</h2>
+                <h2 class="col-12">Comparing {{ lang1_friendlyname }}'s and {{ lang2_friendlyname }}'s {{ concept }}</h2>
             </div>
             <div class="row col-12">
                 The following will eventually be a table of stuff that's populated with things from the languages
@@ -22,12 +22,12 @@
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="text-center">{{ lang1 }}'s Implementation</h5>
+                        <h5 class="text-center">{{ lang1_friendlyname }}'s Implementation</h5>
                     </div>
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="text-center">{{ lang2 }}'s Implementation</h5>
+                        <h5 class="text-center">{{ lang2_friendlyname }}'s Implementation</h5>
                     </div>
                 </div>
             </div>
@@ -50,6 +50,27 @@
         {% endfor %}
     {% endfor %}
 {% endfor %}
-        </div>
 
+           <div class="row">&nbsp;</div>
+           <div class="card-group">
+                <div class="card">
+                    <div class="card-body">&nbsp;</div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang1 }}/{{ concept }}.json">
+                            Want to add or correct information for {{ lang1_friendlyname }}?
+                        </a>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang2 }}/{{ concept }}.json">
+                            Want to add or correct information for {{ lang2_friendlyname }}?
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+        </div>
 {% endblock content %}

--- a/web/templates/reference.html
+++ b/web/templates/reference.html
@@ -4,7 +4,7 @@
 {% block content %}
         <div class="container">
             <div class="row mt-5">
-                <h2 class="col-12">Reference for {{ lang }} for {{ concept }}</h2>
+                <h2 class="col-12">Reference for {{ lang_friendlyname }} for {{ concept }}</h2>
             </div>
             <div class="row col-12">
                 The following will eventually be a table of stuff that's populated with things from the languages
@@ -21,7 +21,7 @@
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="text-center">{{ lang }}'s Implementation</h5>
+                        <h5 class="text-center">{{ lang_friendlyname }}'s Implementation</h5>
                     </div>
                 </div>
             </div>
@@ -43,7 +43,21 @@
         {% endfor %}
     {% endfor %}
 {% endfor %}
-        </div>
 
+           <div class="row">&nbsp;</div>
+           <div class="card-group">
+                <div class="card">
+                    <div class="card-body">&nbsp;</div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang }}/{{ concept }}.json">
+                            Want to add or correct information for {{ lang_friendlyname }}?
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+        </div>
 
 {% endblock content %}

--- a/web/views.py
+++ b/web/views.py
@@ -37,10 +37,10 @@ def compare(request):
             meta_data = meta_file.read()
         meta_data_langs = json.loads(meta_data)["languages"]
 
-        lang1 = request.GET.get('lang1', '')
-        lang2 = request.GET.get('lang2', '')
-        lang1_directory = meta_data_langs.get(lang1)
-        lang2_directory = meta_data_langs.get(lang2)
+        lang1_query_string = request.GET.get('lang1', '')
+        lang2_query_string = request.GET.get('lang2', '')
+        lang1_directory = meta_data_langs.get(lang1_query_string)
+        lang2_directory = meta_data_langs.get(lang2_query_string)
 
         # if not (lang1_directory and lang2_directory):
         #     return HttpResponseBadRequest("Lang does not exist")
@@ -113,10 +113,10 @@ def compare(request):
 
     # DB equivalent of full outer join
     response = {
-        "title": "Comparing" + lang1 + " " + lang2,
+        "title": "Comparing" + lang1_friendly_name + " " + lang2_friendly_name,
         "concept": concept,
-        "lang1": lang1,
-        "lang2": lang2,
+        "lang1": lang1_directory,
+        "lang2": lang2_directory,
         "lang1_friendlyname": lang1_friendly_name,
         "lang2_friendlyname": lang2_friendly_name,
         "categories": both_categories,
@@ -134,8 +134,8 @@ def reference(request):
             meta_data = meta_file.read()
         meta_data_langs = json.loads(meta_data)["languages"]
 
-        lang = request.GET.get('lang', '')
-        lang_directory = meta_data_langs[lang]
+        lang_query_string = request.GET.get('lang', '')
+        lang_directory = meta_data_langs[lang_query_string]
 
         # if not (lang_directory):
         #     return HttpResponseBadRequest("Lang does not exist")
@@ -168,9 +168,9 @@ def reference(request):
         })
 
     response = {
-        "title": "Reference for " + lang,
+        "title": "Reference for " + lang_query_string,
         "concept": concept,
-        "lang": lang,
+        "lang": lang_directory,
         "lang_friendlyname": lang_friendly_name,
         "categories": categories,
         "concepts": concepts


### PR DESCRIPTION
(Closes Issue 66)

This adds a link to the bottom of Compare and Reference pages to add a direct link to GitHub's specific thesaurus data files in hopes of encouraging easy additions from users!

![image](https://user-images.githubusercontent.com/2601974/96509625-504bbf80-122a-11eb-878f-27a3eb32ad36.png)
