### PR TITLE
fix navbar size on small window

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -19,7 +19,7 @@
   color: #fff;
 }
 
-@media (min-width: 767px) {
+@media (min-width: 576px) {
   .navbar-nav {
     height: inherit;
     display: flex;


### PR DESCRIPTION
Hey, 

Navbar should work fine now. The problem was in css where styling was added for navbar-expansion in `md window (767px)`  while navbar was supposed to be expanded only in `sm window (576px)`. Hope that make sense. 
#121

Best,
Biplov 