### PR TITLE
Feature/add php control structures

### DIFF
--- a/web/thesauruses/meta_info.json
+++ b/web/thesauruses/meta_info.json
@@ -4,7 +4,8 @@
     "C#": "csharp",
     "Java": "java",
     "Python": "python",
-    "Scala": "scala"
+    "Scala": "scala",
+    "PHP": "php"
   },
   "structures": {
     "Control Structures": "control_structures.json",

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -1,0 +1,92 @@
+{
+  "meta": {
+    "language": "language_id",
+    "language_version": "version.number",
+    "language_name": "Human-Friendly Language Name"
+  },
+  "categories": {
+    "Conditional Statements (ifs)": [
+      "if_conditional",
+      "if_else_conditional",
+      "if_elseif_conditional",
+      "if_elseif_else_conditional"
+    ],
+    "Loops": [
+      "while_loop",
+      "do_while_loop",
+      "until_loop",
+      "do_until_loop",
+      "for_loops",
+      "foreach_loops"
+    ],
+    "Iterations": [
+      "each_iteration",
+      "map_iteration",
+      "filter_iteration",
+      "fold_iteration",
+      "recursion_iteration"
+    ]
+  },
+  "control_structures": {
+    "if_conditional": {
+      "name": "If conditional",
+      "code": ""
+    },
+    "if_else_conditional": {
+      "name": "If/Else conditional",
+      "code": ""
+    },
+    "if_elseif_conditional": {
+      "name": "If/ElseIf conditional",
+      "code": ""
+    },
+    "if_elseif_else_conditional": {
+      "name": "If/ElseIf/Else conditional",
+      "code": ""
+    },
+    "while_loop": {
+      "name": "While loop",
+      "code": ""
+    },
+    "do_while_loop": {
+      "name": "Do/While loop",
+      "code": ""
+    },
+    "until_loop": {
+      "name": "Until loop",
+      "code": ""
+    },
+    "do_until_loop": {
+      "name": "Do/Until loop",
+      "code": ""
+    },
+    "for_loops": {
+      "name": "For loop",
+      "code": ""
+    },
+    "foreach_loops": {
+      "name": "Foreach loop",
+      "code": ""
+    },
+    "each_iteration": {
+      "name": "Each iteration",
+      "code": ""
+    },
+    "map_iteration": {
+      "name": "Map iteration",
+      "code": ""
+    },
+    "filter_iteration": {
+      "name": "Filter iteration",
+      "code": ""
+    },
+    "fold_iteration": {
+      "name": "Fold iteration",
+      "code": ""
+    },
+    "recursion_iteration": {
+      "name": "Recursion iteration",
+      "code": ""
+    }
+  }
+}

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -27,65 +27,39 @@
   "control_structures": {
     "if_conditional": {
       "name": "If conditional",
-      "code": "if( $true_condition ) { 
-	      	//statement 
-	      }"
+      "code": "if( $true_condition ) {\n    //statement\n}"
     },
     "if_else_conditional": {
       "name": "If/Else conditional",
-      "code": "if( $condition ) {
-	      	// statement
-	      } else { 
-		// else statement 
-	      }"
+      "code": "if( $condition ) {\n    // statement\n} else {\n    // else statement\n}"
     },
     "if_elseif_conditional": {
       "name": "If/ElseIf conditional",
-      "code": "if( $condition ) {
-	          // statement 
-	       } elseif ( $othercondition ) { 
-		  // elseif statement 
-	       }"
+      "code": "if( $condition ) {\n    // statement\n} elseif ( $othercondition ) {\n    // elseif statement\n}"
     },
     "if_elseif_else_conditional": {
       "name": "If/ElseIf/Else conditional",
-      "code": "if( $condition ) {
-	           // statement 
-	       } elseif ( $othercondition ) { 
-		   // elseif statement 
-	       } else { 
-		   // else statement
-	       }"
+      "code": "if( $condition ) {\n    // statement\n} elseif ( $othercondition ) {\n    // elseif statement\n} else {\n    // else statement\n}"
     },
     "while_loop": {
       "name": "While loop",
-      "code": "while( $condition ) { 
-	           // code to be executed 
-	       }"
+      "code": "while( $condition ) {\n    // code to be executed\n}"
     },
     "do_while_loop": {
       "name": "Do/While loop",
-      "code": "do { 
-	          //executable code 
-	       } while ( $condition );"
+      "code": "do {\n    //executable code\n} while ( $condition );"
     },
     "for_loops": {
       "name": "For loop",
-      "code": "for ( $intial_counter, $test_counter, $increment ) { 
-	          // executable code 
-	       }"
+      "code": "for ( $intial_counter, $test_counter, $increment ) {\n    // executable code\n}"
     },
     "foreach_loops": {
       "name": "Foreach loop",
-      "code": "foreach ( $iterable as $item ) { 
-	          // executable code 
-	       }"
+      "code": "foreach ( $iterable as $item ) {\n    // executable code}"
     },
     "map_iteration": {
       "name": "Map iteration",
-      "code": "array_map( function( $element ) { 
-	          // transform element 
-	       }, $array );"
+      "code": "array_map( function( $element ) {\n    // transform element\n}, $array );"
     },
     "filter_iteration": {
       "name": "Filter iteration",

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "language": "language_id",
-    "language_version": "version.number",
-    "language_name": "Human-Friendly Language Name"
+    "language": "php",
+    "language_version": "7.4",
+    "language_name": "PHP"
   },
   "categories": {
     "Conditional Statements (ifs)": [
@@ -20,73 +20,50 @@
       "foreach_loops"
     ],
     "Iterations": [
-      "each_iteration",
       "map_iteration",
-      "filter_iteration",
-      "fold_iteration",
-      "recursion_iteration"
+      "filter_iteration"
     ]
   },
   "control_structures": {
     "if_conditional": {
       "name": "If conditional",
-      "code": ""
+      "code": "if( condition ) { statement }"
     },
     "if_else_conditional": {
       "name": "If/Else conditional",
-      "code": ""
+      "code": "if( condition ) { statement } else { else statement }"
     },
     "if_elseif_conditional": {
       "name": "If/ElseIf conditional",
-      "code": ""
+      "code": "if( condition ) { statement } elseif { elseif statement }"
     },
     "if_elseif_else_conditional": {
       "name": "If/ElseIf/Else conditional",
-      "code": ""
+      "code": "if( condition ) { statement } elseif { elseif statement } else { else statement }"
     },
     "while_loop": {
       "name": "While loop",
-      "code": ""
+      "code": "while( true condition ) { code to be executed }"
     },
     "do_while_loop": {
       "name": "Do/While loop",
-      "code": ""
-    },
-    "until_loop": {
-      "name": "Until loop",
-      "code": ""
-    },
-    "do_until_loop": {
-      "name": "Do/Until loop",
-      "code": ""
+      "code": "do { executable code } while ( true condition );"
     },
     "for_loops": {
       "name": "For loop",
-      "code": ""
+      "code": "for ( intial_counter, test_counter, increment ) { executable code }"
     },
     "foreach_loops": {
       "name": "Foreach loop",
-      "code": ""
-    },
-    "each_iteration": {
-      "name": "Each iteration",
-      "code": ""
+      "code": "foreach ( iterable as item ) { executable code }"
     },
     "map_iteration": {
       "name": "Map iteration",
-      "code": ""
+      "code": "array_map( function( element ) { transform element }, array );"
     },
     "filter_iteration": {
       "name": "Filter iteration",
-      "code": ""
-    },
-    "fold_iteration": {
-      "name": "Fold iteration",
-      "code": ""
-    },
-    "recursion_iteration": {
-      "name": "Recursion iteration",
-      "code": ""
+      "code": "array_filter( array, function( element ) { return a bool } );"
     }
   }
 }

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -9,19 +9,23 @@
       "if_conditional",
       "if_else_conditional",
       "if_elseif_conditional",
-      "if_elseif_else_conditional"
+      "if_elseif_else_conditional",
+      "ternary_conditional"
     ],
     "Loops": [
       "while_loop",
       "do_while_loop",
       "until_loop",
       "do_until_loop",
-      "for_loops",
-      "foreach_loops"
+      "for_loop",
+      "foreach_loop"
     ],
     "Iterations": [
+      "each_iteration",
       "map_iteration",
-      "filter_iteration"
+      "filter_iteration",
+      "fold_iteration",
+      "recursion_iteration"
     ]
   },
   "control_structures": {

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -45,6 +45,10 @@
       "name": "If/ElseIf/Else conditional",
       "code": "if( $condition ) {\n    // statement\n} elseif ( $othercondition ) {\n    // elseif statement\n} else {\n    // else statement\n}"
     },
+    "ternary_conditional":{
+      "name": "Ternary conditional",
+      "code": "$value ? $value : $other_value;\n$value ?: $other_value;"
+    },
     "while_loop": {
       "name": "While loop",
       "code": "while( $condition ) {\n    // code to be executed\n}"

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -27,43 +27,69 @@
   "control_structures": {
     "if_conditional": {
       "name": "If conditional",
-      "code": "if( condition ) { statement }"
+      "code": "if( $true_condition ) { 
+	      	//statement 
+	      }"
     },
     "if_else_conditional": {
       "name": "If/Else conditional",
-      "code": "if( condition ) { statement } else { else statement }"
+      "code": "if( $condition ) {
+	      	// statement
+	      } else { 
+		// else statement 
+	      }"
     },
     "if_elseif_conditional": {
       "name": "If/ElseIf conditional",
-      "code": "if( condition ) { statement } elseif { elseif statement }"
+      "code": "if( $condition ) {
+	          // statement 
+	       } elseif ( $othercondition ) { 
+		  // elseif statement 
+	       }"
     },
     "if_elseif_else_conditional": {
       "name": "If/ElseIf/Else conditional",
-      "code": "if( condition ) { statement } elseif { elseif statement } else { else statement }"
+      "code": "if( $condition ) {
+	           // statement 
+	       } elseif ( $othercondition ) { 
+		   // elseif statement 
+	       } else { 
+		   // else statement
+	       }"
     },
     "while_loop": {
       "name": "While loop",
-      "code": "while( true condition ) { code to be executed }"
+      "code": "while( $condition ) { 
+	           // code to be executed 
+	       }"
     },
     "do_while_loop": {
       "name": "Do/While loop",
-      "code": "do { executable code } while ( true condition );"
+      "code": "do { 
+	          //executable code 
+	       } while ( $condition );"
     },
     "for_loops": {
       "name": "For loop",
-      "code": "for ( intial_counter, test_counter, increment ) { executable code }"
+      "code": "for ( $intial_counter, $test_counter, $increment ) { 
+	          // executable code 
+	       }"
     },
     "foreach_loops": {
       "name": "Foreach loop",
-      "code": "foreach ( iterable as item ) { executable code }"
+      "code": "foreach ( $iterable as $item ) { 
+	          // executable code 
+	       }"
     },
     "map_iteration": {
       "name": "Map iteration",
-      "code": "array_map( function( element ) { transform element }, array );"
+      "code": "array_map( function( $element ) { 
+	          // transform element 
+	       }, $array );"
     },
     "filter_iteration": {
       "name": "Filter iteration",
-      "code": "array_filter( array, function( element ) { return a bool } );"
+      "code": "array_filter( $array, function( $element ) { // return a bool } );"
     }
   }
 }

--- a/web/thesauruses/php/control_strucutres.json
+++ b/web/thesauruses/php/control_strucutres.json
@@ -59,11 +59,15 @@
     },
     "for_loops": {
       "name": "For loop",
-      "code": "for ( $intial_counter, $test_counter, $increment ) {\n    // executable code\n}"
+      "code": "for ( $intial_counter; $test_counter; $increment ) {\n    // executable code\n}"
     },
-    "foreach_loops": {
+    "foreach_loop": {
       "name": "Foreach loop",
       "code": "foreach ( $iterable as $item ) {\n    // executable code}"
+    },
+    "each_iteration": {
+      "name": "Each iteration",
+      "code": ""
     },
     "map_iteration": {
       "name": "Map iteration",
@@ -72,6 +76,14 @@
     "filter_iteration": {
       "name": "Filter iteration",
       "code": "array_filter( $array, function( $element ) { // return a bool } );"
+    },
+    "fold_iteration": {
+      "name": "Fold iteration",
+      "code": ""
+    },
+    "recursion_iteration": {
+      "name": "Recursion iteration",
+      "code": ""
     }
   }
 }


### PR DESCRIPTION
Closes #111 

Hello!

This adds PHP control structure documentation.
I tested locally but I couldn't figure out how to view PHP control structures. I tried updating web/thesauruses/meta_info.json but it seems like there is some sort of db import step I'm missing due to my lack of django/python knowledge. 

I'm not sure what to do about the foreach loop as in PHP arrays can be associative in which case one could have a different structure. I added a foreach associative example but we may want to take another approach.

Oh, I'm also not sure if I was supposed to modify web/thesauruses/meta_info.json or not...

Thanks,
Gary