### PR TITLE
Feature/add php functions

### DIFF
--- a/web/thesauruses/php/functions.json
+++ b/web/thesauruses/php/functions.json
@@ -19,6 +19,10 @@
       "anonymous_function_no_parameters",
       "anonymous_function_with_parameters",
       "anonymous_function_variable_parameters"
+    ],
+    "Subroutines": [
+      "call_subroutine",
+      "return_from_subroutine"
     ]
   },
   "functions": {
@@ -57,6 +61,14 @@
     "anonymous_function_variable_parameters": {
       "name": "Anonymous function that takes an unknown number of parameters",
       "code": "function( ...$params ) : null {\n    // Code $params is an array of items\n}"
+    },
+    "call_subroutine": {
+      "name": "Call subroutine",
+      "code": ""
+    },
+    "return_from_subroutine": {
+      "name": "Return from subroutine",
+      "code": ""
     }
   }
 }

--- a/web/thesauruses/php/functions.json
+++ b/web/thesauruses/php/functions.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "language": "language_id",
-    "language_version": "version.number",
-    "language_name": "Human-Friendly Language Name"
+    "language": "php",
+    "language_version": "7.4",
+    "language_name": "PHP"
   },
   "categories": {
     "Void Functions": [
@@ -19,56 +19,44 @@
       "anonymous_function_no_parameters",
       "anonymous_function_with_parameters",
       "anonymous_function_variable_parameters"
-    ],
-    "Subroutines": [
-      "call_subroutine",
-      "return_from_subroutine"
     ]
   },
   "functions": {
     "void_function_no_parameters": {
       "name": "Function that does not return a value and takes no parameters",
-      "code": ""
+      "code": "function void_function_no_parameters() : null {\n    // Code\n}"
     },
     "void_function_with_parameters": {
       "name": "Function that does not return a value and that takes 1 or more defined parameters",
-      "code": ""
+      "code": "function void_function_with_parameters( $param1, $param2 ) : null {\n    // Code\n}"
     },
     "void_function_variable_parameters": {
       "name": "Function that does not return a value and function that takes an unknown number of parameters",
-      "code": ""
+      "code": "function void_function_variable_parameters( ...$params ) : null {\n    // Code $params is an array of items\n}"
     },
     "return_value_function_no_parameters": {
       "name": "Function that returns a value and takes no parameters",
-      "code": ""
+      "code": "function return_value_function_no_parameters() : int {\n    return 7; // or any integer\n}"
     },
     "return_value_function_with_parameters": {
       "name": "Function that returns a value and takes 1 or more defined parameters",
-      "code": ""
+      "code": "function return_value_function_with_parameters( $param ) : string {\n    return '7'; // or any string\n}"
     },
     "return_value_function_variable_parameters": {
       "name": "Function that returns a value and takes an unknown number of parameters",
-      "code": ""
+      "code": "function return_value_function_variable_parameters( ...$params ) : bool {\n    return true; // Code $params is an array of items\n}"
     },
     "anonymous_function_no_parameters": {
       "name": "Anonymous function that takes no parameters",
-      "code": ""
+      "code": "function() : null {\n    // Code\n}"
     },
     "anonymous_function_with_parameters": {
       "name": "Anonymous function that takes 1 or more defined parameters",
-      "code": ""
+      "code": "function( $param1, $param2 ) : null {\n    // Code\n}"
     },
     "anonymous_function_variable_parameters": {
       "name": "Anonymous function that takes an unknown number of parameters",
-      "code": ""
-    },
-    "call_subroutine": {
-      "name": "Call subroutine",
-      "code": ""
-    },
-    "return_from_subroutine": {
-      "name": "Return from subroutine",
-      "code": ""
+      "code": "function( ...$params ) : null {\n    // Code $params is an array of items\n}"
     }
   }
 }

--- a/web/thesauruses/php/functions.json
+++ b/web/thesauruses/php/functions.json
@@ -1,0 +1,74 @@
+{
+  "meta": {
+    "language": "language_id",
+    "language_version": "version.number",
+    "language_name": "Human-Friendly Language Name"
+  },
+  "categories": {
+    "Void Functions": [
+      "void_function_no_parameters",
+      "void_function_with_parameters",
+      "void_function_variable_parameters"
+    ],
+    "Return Value Functions": [
+      "return_value_function_no_parameters",
+      "return_value_function_with_parameters",
+      "return_value_function_variable_parameters"
+    ],
+    "Lambda/Anonymous Functions": [
+      "anonymous_function_no_parameters",
+      "anonymous_function_with_parameters",
+      "anonymous_function_variable_parameters"
+    ],
+    "Subroutines": [
+      "call_subroutine",
+      "return_from_subroutine"
+    ]
+  },
+  "functions": {
+    "void_function_no_parameters": {
+      "name": "Function that does not return a value and takes no parameters",
+      "code": ""
+    },
+    "void_function_with_parameters": {
+      "name": "Function that does not return a value and that takes 1 or more defined parameters",
+      "code": ""
+    },
+    "void_function_variable_parameters": {
+      "name": "Function that does not return a value and function that takes an unknown number of parameters",
+      "code": ""
+    },
+    "return_value_function_no_parameters": {
+      "name": "Function that returns a value and takes no parameters",
+      "code": ""
+    },
+    "return_value_function_with_parameters": {
+      "name": "Function that returns a value and takes 1 or more defined parameters",
+      "code": ""
+    },
+    "return_value_function_variable_parameters": {
+      "name": "Function that returns a value and takes an unknown number of parameters",
+      "code": ""
+    },
+    "anonymous_function_no_parameters": {
+      "name": "Anonymous function that takes no parameters",
+      "code": ""
+    },
+    "anonymous_function_with_parameters": {
+      "name": "Anonymous function that takes 1 or more defined parameters",
+      "code": ""
+    },
+    "anonymous_function_variable_parameters": {
+      "name": "Anonymous function that takes an unknown number of parameters",
+      "code": ""
+    },
+    "call_subroutine": {
+      "name": "Call subroutine",
+      "code": ""
+    },
+    "return_from_subroutine": {
+      "name": "Return from subroutine",
+      "code": ""
+    }
+  }
+}


### PR DESCRIPTION
closes #99 

This adds php functions. PHP is so silly, the type-hinting on return values is not a requirement, though...it's a good idea. I added return values for clarity but not sure if there is a way to indicate they are optional?
Or...is that actually a different type of function to document? That is to say:
void_function_with_parameters 
void_function_with_parameters_declared_return_type
void_function_with_typed_parameters
void_function_with_typed_parameters_declared_return_type