### PR TITLE
add http to https redirect in non debug envs

### DIFF
--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -32,6 +32,9 @@ if SYSTEM_ENV == 'PRODUCTION' or SYSTEM_ENV == 'STAGING':
 else:
     DEBUG = True
 
+# redirect all http requests to https in non debugging envs
+SECURE_SSL_REDIRECT = not DEBUG
+
 ALLOWED_HOSTS = []
 
 


### PR DESCRIPTION
Fixes #136,
Please verify that it works locally and on prod. I have verified locally. 
Also a gotcha that I found is that browsers can cache redirects made i.e. when I tried going to http with redirects off it didn't redirect (expected), I turned on redirects and went to http and it redirected to https (expected). Now I switched redirects off again and it was still redirecting to https from http. However when I tried this in a new incognito tab for every attempt, all behavior was expected.