### PR TITLE
Add Haskell function syntax

### DIFF
--- a/web/thesauruses/haskell/functions.json
+++ b/web/thesauruses/haskell/functions.json
@@ -1,0 +1,74 @@
+{
+  "meta": {
+    "language": "haskell",
+    "language_version": "2010",
+    "language_name": "Haskell"
+  },
+  "categories": {
+    "Void Functions": [
+      "void_function_no_parameters",
+      "void_function_with_parameters",
+      "void_function_variable_parameters"
+    ],
+    "Return Value Functions": [
+      "return_value_function_no_parameters",
+      "return_value_function_with_parameters",
+      "return_value_function_variable_parameters"
+    ],
+    "Lambda/Anonymous Functions": [
+      "anonymous_function_no_parameters",
+      "anonymous_function_with_parameters",
+      "anonymous_function_variable_parameters"
+    ],
+    "Subroutines": [
+      "call_subroutine",
+      "return_from_subroutine"
+    ]
+  },
+  "functions": {
+    "void_function_no_parameters": {
+      "name": "Function that does not return a value and takes no parameters",
+      "code": ""
+    },
+    "void_function_with_parameters": {
+      "name": "Function that does not return a value and that takes 1 or more defined parameters",
+      "code": ""
+    },
+    "void_function_variable_parameters": {
+      "name": "Function that does not return a value and function that takes an unknown number of parameters",
+      "code": ""
+    },
+    "return_value_function_no_parameters": {
+      "name": "Function that returns a value and takes no parameters",
+      "code": ""
+    },
+    "return_value_function_with_parameters": {
+      "name": "Function that returns a value and takes 1 or more defined parameters",
+      "code": "function_name parameter parameter2 = expression"
+    },
+    "return_value_function_variable_parameters": {
+      "name": "Function that returns a value and takes an unknown number of parameters",
+      "code": ""
+    },
+    "anonymous_function_no_parameters": {
+      "name": "Anonymous function that takes no parameters",
+      "code": ""
+    },
+    "anonymous_function_with_parameters": {
+      "name": "Anonymous function that takes 1 or more defined parameters",
+      "code": "\\parameter parameter2 -> expression"
+    },
+    "anonymous_function_variable_parameters": {
+      "name": "Anonymous function that takes an unknown number of parameters",
+      "code": ""
+    },
+    "call_subroutine": {
+      "name": "Call subroutine",
+      "code": ""
+    },
+    "return_from_subroutine": {
+      "name": "Return from subroutine",
+      "code": ""
+    }
+  }
+}


### PR DESCRIPTION
Adding the syntax for Haskell functions.

I realize this looks a little sparse but most concepts just don't make sense in a purely functional language like Haskell.

The only thing I am a little unsure about is the call_subroutine one is that just meant to be function invocation? In that case I would add it.