### PR TITLE
Respect newlines and indentation of concept files

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -108,6 +108,10 @@ footer p {
   background-color: #fff;
 }
 
+.card-body pre {
+  color: #e83e8c;
+}
+
 a.toTop {
   color: #304ffe;
   text-decoration: none;

--- a/web/templates/comparecard.html
+++ b/web/templates/comparecard.html
@@ -2,7 +2,7 @@
     <div class="card-body">
         <div>
             {% if code %}
-                <code>{{ code|linebreaksbr }}</code>
+                <pre>{{ code }}</pre>
             {% else %}
                 <div>Unsupported or Not Needed</div>
             {% endif %}


### PR DESCRIPTION
I think treating the code snippets as pre-formatted text with `<pre>` is an appropriate way of resolve #156 

The css changes are necessary to keep the look and feel.

A detail that is changed by this is that now long lines no longer automatically wrap, but I don't know if we want that to happen or if sideways scrolling is fine in that case.