### PR TITLE
Replace django-heroku to django-on-heroku

### DIFF
--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -84,13 +84,13 @@ WSGI_APPLICATION = 'codethesaurus.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
-}
-# DATABASES = {}
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3',
+#         'NAME': BASE_DIR / 'db.sqlite3',
+#     }
+# }
+DATABASES = {}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
@@ -146,4 +146,4 @@ STATICFILES_DIRS = (
 )
 
 # Configure Django App for Heroku.
-django_on_heroku.settings(locals(), databases=True, staticfiles=True)
+django_on_heroku.settings(locals(), test_runner=False, databases=False, staticfiles=True)

--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -84,13 +84,12 @@ WSGI_APPLICATION = 'codethesaurus.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': BASE_DIR / 'db.sqlite3',
-#     }
-# }
-DATABASES = {}
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -84,13 +84,13 @@ WSGI_APPLICATION = 'codethesaurus.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': BASE_DIR / 'db.sqlite3',
-#     }
-# }
-DATABASES = {}
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+# DATABASES = {}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
@@ -146,4 +146,4 @@ STATICFILES_DIRS = (
 )
 
 # Configure Django App for Heroku.
-django_on_heroku.settings(locals(), databases=False, staticfiles=True)
+django_on_heroku.settings(locals(), databases=True, staticfiles=True)

--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -84,12 +84,12 @@ WSGI_APPLICATION = 'codethesaurus.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
-}
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3',
+#         'NAME': BASE_DIR / 'db.sqlite3',
+#     }
+# }
 
 
 # Password validation

--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 import os
-import django_heroku
+import django_on_heroku
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -57,8 +57,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware'
+    'django.middleware.clickjacking.XFrameOptionsMiddleware'
 ]
 
 ROOT_URLCONF = 'codethesaurus.urls'
@@ -146,7 +145,5 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
 
-# Activate Django-Heroku.
-# django_heroku.settings(locals())
 # Configure Django App for Heroku.
-django_heroku.settings(locals(), test_runner=False)
+django_on_heroku.settings(locals(), databases=False, staticfiles=True)

--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -90,7 +90,7 @@ WSGI_APPLICATION = 'codethesaurus.wsgi.application'
 #         'NAME': BASE_DIR / 'db.sqlite3',
 #     }
 # }
-
+DATABASES = {}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ astroid==2.4.2
 colorama==0.4.3
 dj-database-url==0.5.0
 Django==3.1.6
-django-heroku==0.3.1
+django-on-heroku==1.1.2
 gunicorn==20.0.4
 isort==5.5.4
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-psycopg2==2.8.6
+psycopg2-binary==2.8.6
 pylint==2.6.0
 pytz==2020.1
 six==1.15.0


### PR DESCRIPTION
This should remove the old, abandoned django-heroku and replace it with django-on-heroku. This should re-enable static file serving as well as simplify installation for other people working on this project.