### PR TITLE
Add prettier error messages for 400, 403, 404, and 500 errors

### DIFF
--- a/codethesaurus/urls.py
+++ b/codethesaurus/urls.py
@@ -20,3 +20,8 @@ urlpatterns = [
     path('', include('web.urls')),
     path('admin/', admin.site.urls),
 ]
+
+handler400 = 'web.views.error_handler_400_bad_request'
+handler403 = 'web.views.error_handler_403_forbidden'
+handler404 = 'web.views.error_handler_404_not_found'
+handler500 = 'web.views.error_handler_500_server_error'

--- a/web/templates/error400.html
+++ b/web/templates/error400.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
-{% load templatetags %}
 
 {% block content %}
 
-    <div><strong>400 Error!</strong></div>
-
-    <div>I don't know what you tried to request, but it didn't work!</div>
-
-    <div>Go back to our <a href="/">home page</a>!</div>
-
+<div class="container">
+  <div class="bg-light p-5 rounded">
+    <h1>400 Error - Bad Request!</h1>
+    <p class="lead">I don't know what you were trying to request, but it didn't work!</p>
+    <a class="btn btn-lg btn-primary" href="/" role="button">Go to the Home Page &raquo;</a>
+  </div>
+</div>
 
 {% endblock content %}

--- a/web/templates/error400.html
+++ b/web/templates/error400.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load templatetags %}
+
+{% block content %}
+
+    <div><strong>400 Error!</strong></div>
+
+    <div>I don't know what you tried to request, but it didn't work!</div>
+
+    <div>Go back to our <a href="/">home page</a>!</div>
+
+
+{% endblock content %}

--- a/web/templates/error403.html
+++ b/web/templates/error403.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load templatetags %}
+
+{% block content %}
+
+    <div><strong>403 Error!</strong></div>
+
+    <div>I don't know who you are, but you can't access that!</div>
+
+    <div>Go back to our <a href="/">home page</a>!</div>
+
+
+{% endblock content %}

--- a/web/templates/error403.html
+++ b/web/templates/error403.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
-{% load templatetags %}
 
 {% block content %}
 
-    <div><strong>403 Error!</strong></div>
-
-    <div>I don't know who you are, but you can't access that!</div>
-
-    <div>Go back to our <a href="/">home page</a>!</div>
-
+<div class="container">
+  <div class="bg-light p-5 rounded">
+    <h1>403 Error - Forbidden!</h1>
+    <p class="lead">I don't know what you were trying to access but you can't!</p>
+    <a class="btn btn-lg btn-primary" href="/" role="button">Go to the Home Page &raquo;</a>
+  </div>
+</div>
 
 {% endblock content %}

--- a/web/templates/error404.html
+++ b/web/templates/error404.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load templatetags %}
+
+{% block content %}
+
+    <div><strong>404 Error!</strong></div>
+
+    <div>I don't know what you're looking for, but it's clearly not here.</div>
+
+    <div>Go back to our <a href="/">home page</a>!</div>
+
+
+{% endblock content %}

--- a/web/templates/error404.html
+++ b/web/templates/error404.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
-{% load templatetags %}
 
 {% block content %}
 
-    <div><strong>404 Error!</strong></div>
-
-    <div>I don't know what you're looking for, but it's clearly not here.</div>
-
-    <div>Go back to our <a href="/">home page</a>!</div>
-
+<div class="container">
+  <div class="bg-light p-5 rounded">
+    <h1>404 Error - Not Found!</h1>
+    <p class="lead">I don't know what you were looking for, but it's not here!</p>
+    <a class="btn btn-lg btn-primary" href="/" role="button">Go to the Home Page &raquo;</a>
+  </div>
+</div>
 
 {% endblock content %}

--- a/web/templates/error500.html
+++ b/web/templates/error500.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
-{% load templatetags %}
 
 {% block content %}
 
-    <div><strong>500 Error!</strong></div>
-
-    <div>I don't know what happened, but some code thing broke!</div>
-
-    <div>Go back to our <a href="/">home page</a>!</div>
-
+<div class="container">
+  <div class="bg-light p-5 rounded">
+    <h1>500 Error - Server Error!</h1>
+    <p class="lead">I don't know what went wrong, but the code broke!</p>
+    <a class="btn btn-lg btn-primary" href="/" role="button">Go to the Home Page &raquo;</a>
+  </div>
+</div>
 
 {% endblock content %}

--- a/web/templates/error500.html
+++ b/web/templates/error500.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load templatetags %}
+
+{% block content %}
+
+    <div><strong>500 Error!</strong></div>
+
+    <div>I don't know what happened, but some code thing broke!</div>
+
+    <div>Go back to our <a href="/">home page</a>!</div>
+
+
+{% endblock content %}

--- a/web/views.py
+++ b/web/views.py
@@ -2,7 +2,7 @@ import json
 import os
 import random
 
-from django.http import HttpResponseNotFound
+from django.http import HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import render
 from django.utils.html import escape, strip_tags
 
@@ -185,7 +185,7 @@ def reference(request):
     for category_key in lang.categories:
         categories.append({
             "id": category_key,
-            "concepts": meta_structure.categories[category_key] # meta_lang_categories[category_key]
+            "concepts": meta_structure.categories[category_key]  # meta_lang_categories[category_key]
         })
 
     for concept_key in lang.concepts:
@@ -207,3 +207,24 @@ def reference(request):
     }
 
     return render(request, 'reference.html', response)
+
+
+def error_handler_400_bad_request(request, exception):
+    response = render(request, 'error400.html')
+    return HttpResponseBadRequest(response)
+
+
+def error_handler_403_forbidden(request, exception):
+    response = render(request, 'error403.html')
+    return HttpResponseForbidden(response)
+
+
+def error_handler_404_not_found(request, exception):
+    response = render(request, 'error404.html')
+    return HttpResponseNotFound(response)
+
+
+def error_handler_500_server_error(request):
+    response = render(request, 'error500.html')
+    return HttpResponseServerError(response)
+


### PR DESCRIPTION
Closes #67 

Adds error handler routines for catching 400, 403, 404, and 500 errors and passes them to nice-looking views.