### PR TITLE
Cleanup some whitespace errors

### DIFF
--- a/web/thesauruses/cpp/control_structures.json
+++ b/web/thesauruses/cpp/control_structures.json
@@ -9,106 +9,43 @@
       "if_conditional",
       "if_else_conditional",
       "if_elseif_conditional",
-      "if_elseif_else_conditional"
+      "if_elseif_else_conditional",
+      "ternary_conditional"
     ],
     "Loops": [
       "while_loop",
       "do_while_loop",
-      "until_loop",
-      "do_until_loop",
       "for_loops",
       "foreach_loops"
-    ],
-    "Iterations": [
-      "each_iteration",
-      "map_iteration",
-      "filter_iteration",
-      "fold_iteration",
-      "recursion_iteration"
     ]
   },
   "control_structures": {
     "if_conditional": {
-      "name": "If conditional",
-      "code": "
-      if(condition){\n
-        statements;\n
-      }"
+      "code": "if (condition) {\n    statements;\n}"
     },
     "if_else_conditional": {
-      "name": "If/Else conditional",
-      "code": "
-      if(condition){\n
-        statements;\n
-      }\n
-      else{\n
-        statements;\n
-      }"
+      "code": "if (condition) {\n    statements;\n} else {\n    statements;\n}"
     },
     "if_elseif_conditional": {
-      "name": "If/ElseIf conditional",
-      "code": "
-      if(condition){\n
-        statements;\n
-      }\n
-      else if(condition){\n
-          statements;\n
-      }"
+      "code": "if (condition) {\n    statements;\n} else if (condition) {\n    statements;\n}"
     },
     "if_elseif_else_conditional": {
-      "name": "If/ElseIf/Else conditional",
-      "code": "
-      if(condition){\n
-        statements;\n
-      }\n
-      else if(condition){\n
-          statements;\n
-      }\n
-      else{\n
-        statements;\n
-      }"
+      "code": "if (condition) {\n    statements;\n} else if (condition) {\n    statements;\n} else {\n    statements;\n}"
+    },
+    "ternary_conditional": {
+      "code": "condition ? expression_if_true : expression_if_false"
     },
     "while_loop": {
-      "name": "While loop",
-      "code": "
-      while(condition){\n
-        statements;\n
-      }"
+      "code": "while (condition) {\n    statements;\n}"
     },
     "do_while_loop": {
-      "name": "Do/While loop",
-      "code": "
-      do{\n
-        statements;\n
-      }while(condition)"
+      "code": "do {\n    statements;\n} while (condition);"
     },
-    "until_loop": {
+    "for_loop": {
+      "code": "for (initialization; condition; incrementor) {\n    statements;\n}"
     },
-    "do_until_loop": {
-    },
-    "for_loops": {
-      "name": "For loop",
-      "code": "
-      for(initialization; condition; incrementor){\n
-        statements;\n
-      }"
-    },
-    "foreach_loops": {
-      "name": "Foreach loop",
-      "code": "
-      for(variable: array/vector){\n
-        statements;\n
-      } "
-    },
-    "each_iteration": {
-    },
-    "map_iteration": {
-    },
-    "filter_iteration": {
-    },
-    "fold_iteration": {
-    },
-    "recursion_iteration": {
+    "foreach_loop": {
+      "code": "for (variable: array/vector) {\n    statements;\n} "
     }
   }
 }

--- a/web/thesauruses/cpp/data_types.json
+++ b/web/thesauruses/cpp/data_types.json
@@ -10,11 +10,9 @@
       "integer_16_bit",
       "integer_32_bit",
       "integer_64_bit",
-      "integer_as_object",
       "float_16_bit",
       "float_32_bit",
-      "float_64_bit",
-      "float_as_object"
+      "float_64_bit"
     ],
     "Strings": [
       "string_as_object",
@@ -43,10 +41,6 @@
       "name": "64-bit integer",
       "code": "long long"
     },
-    "integer_as_object": {
-      "name": "Object-based Integer",
-      "code": null
-    },
     "float_16_bit": {
       "name": "16-bit floating point",
       "code": "float"
@@ -58,10 +52,6 @@
     "float_64_bit": {
       "name": "64-bit floating point",
       "code": "long double"
-    },
-    "float_as_object": {
-      "name": "Object-based floating point",
-      "code": null
     },
     "string_as_object": {
       "name": "String as an object",

--- a/web/thesauruses/python/control_structures.json
+++ b/web/thesauruses/python/control_structures.json
@@ -14,68 +14,37 @@
     ],
     "Loops": [
       "while_loop",
-      "do_while_loop",
-      "until_loop",
-      "do_until_loop",
       "for_loop",
       "foreach_loop"
     ],
     "Iterations": [
-      "each_iteration",
       "map_iteration",
-      "filter_iteration",
-      "fold_iteration",
-      "recursion_iteration"
+      "filter_iteration"
     ]
   },
   "control_structures": {
     "if_conditional": {
-      "name": "If conditional",
       "code": "if condition:\n    statements"
     },
     "if_else_conditional": {
-      "name": "If/Else conditional",
       "code": "if condition:\n    statements\nelse:\n    statements"
     },
     "if_elseif_conditional": {
-      "name": "If/ElseIf conditional",
       "code": "if condition:\n    statements\nelif:\n    statements"
     },
     "if_elseif_else_conditional": {
-      "name": "If/ElseIf/Else conditional",
-      "code": "if condition:\n    statements\nelif condition:\n    statements\nelse:    statements"
+      "code": "if condition:\n    statements\nelif condition:\n    statements\nelse:\n    statements"
     },
     "ternary_conditional": {
       "name": "Conditional (ternary) Operator",
-      "code": ""
+      "code": "expression_if_true if condition else expression_if_false"
     },
     "while_loop": {
       "name": "While loop",
       "code": "while condition:\n    statements"
     },
-    "do_while_loop": {
-      "name": "",
-      "code": ""
-    },
-    "until_loop": {
-      "name": "",
-      "code": ""
-    },
-    "do_until_loop": {
-      "name": "",
-      "code": ""
-    },
-    "for_loop": {
-      "name": "For loop",
-      "code": "for iterator in iterable:\n    statements"
-    },
     "foreach_loop": {
-      "name": "",
-      "code": ""
-    },
-    "each_iteration": {
-      "name": "",
-      "code": ""
+      "code": "for iterator in iterable:\n    statements"
     },
     "map_iteration": {
       "name": "Map iteration",
@@ -84,14 +53,6 @@
     "filter_iteration": {
       "name": "Filter iteration",
       "code": "filter(function, iterable)"
-    },
-    "fold_iteration": {
-      "name": "",
-      "code": ""
-    },
-    "recursion_iteration": {
-      "name": "",
-      "code": ""
     }
   }
 }

--- a/web/thesauruses/python/functions.json
+++ b/web/thesauruses/python/functions.json
@@ -19,51 +19,32 @@
       "anonymous_function_no_parameters",
       "anonymous_function_with_parameters",
       "anonymous_function_variable_parameters"
-    ],
-    "Subroutines": [
-      "call_subroutine",
-      "return_from_subroutine"
     ]
   },
   "functions": {
     "void_function_no_parameters": {
       "name": "Function that does not return a value and takes no parameters",
-      "code": "
-      def function_name():\n
-        statements"
+      "code": "def function_name():\n    statements"
     },
     "void_function_with_parameters": {
       "name": "Function that does not return a value and that takes 1 or more defined parameters",
-      "code": "
-      def function_name(parameter, parameter_1):\n
-        statements"
+      "code": "def function_name(parameter, parameter_1):\n    statements"
     },
     "void_function_variable_parameters": {
       "name": "Function that does not return a value and function that takes an unknown number of parameters",
-      "code": "
-      def function_name(*parameter_name):\n
-        statements"
+      "code": "def function_name(*parameter_name):\n    statements"
     },
     "return_value_function_no_parameters": {
       "name": "Function that returns a value and takes no parameters",
-      "code": "
-      def function_name():\n
-        statements\n
-        return expression"
+      "code": "def function_name():\n    statements\n    return expression"
     },
     "return_value_function_with_parameters": {
       "name": "Function that returns a value and takes 1 or more defined parameters",
-      "code": "
-      def function_name(parameter, parameter_1):\n
-        statements\n
-        return expression"
+      "code": "def function_name(parameter, parameter_1):\n    statements\n    return expression"
     },
     "return_value_function_variable_parameters": {
       "name": "Function that returns a value and takes an unknown number of parameters",
-      "code": "
-      def function_name(*parameter_name):\n
-        statements\n
-        return expression"
+      "code": "def function_name(*parameter_name):\n    statements\n    return expression"
     },
     "anonymous_function_no_parameters": {
       "name": "Anonymous function that takes no parameters",
@@ -76,10 +57,6 @@
     "anonymous_function_variable_parameters": {
       "name": "Anonymous function that takes an unknown number of parameters",
       "code": "lambda *parameter : expression"
-    },
-    "call_subroutine": {
-      },
-    "return_from_subroutine": {
-      }
+    }
   }
 }


### PR DESCRIPTION
I noticed some errors invalidated some of the json files resulting in the corresponding pages 404ing.

While I was in the files I also removed some obsolete fields and added implementations for a ternary conditional where applicable.

close #159, close #160