### PR TITLE
Add 'not-implemented' to thesaurus files for clearer distinguishing of null vs gone

### DIFF
--- a/web/templates/comparecard.html
+++ b/web/templates/comparecard.html
@@ -1,16 +1,12 @@
 <div class="card">
     <div class="card-body">
+    {% if code %}
+        <div class="syntax">{{ code | safe }}</div>
+    {% endif %}
+    {% if comment %}
         <div>
-            {% if code %}
-                <div class="syntax">{{ code | safe }}</div>
-            {% else %}
-                <div>Unsupported or Not Needed</div>
-            {% endif %}
-        </div>
-        <div>
-            {% if comment %}
                 {{ comment }}
-            {% endif %}
         </div>
+    {% endif %}
     </div>
 </div>

--- a/web/thesauruses/ada/control_structures.json
+++ b/web/thesauruses/ada/control_structures.json
@@ -20,35 +20,35 @@
   },
   "control_structures": {
     "if_conditional": {
-      "name": "If conditional",
+
       "code": "if condition then\n    statements;\nend if;"
     },
     "if_else_conditional": {
-      "name": "If/Else conditional",
+
       "code": "if condition then\n    statements;\nelse\n    statements;\nend if;"
     },
     "if_elseif_conditional": {
-      "name": "If/ElseIf conditional",
+
       "code": "if condition then\n    statements;\nelsif condition then\n    statements;\nend if;"
     },
     "if_elseif_else_conditional": {
-      "name": "If/ElseIf/Else conditional",
+
       "code": "if condition then\n    statements;\nelsif condition then\n    statements;\nelse\n    statements;\nend if;"
     },
     "ternary_conditional": {
-      "name": "Ternary conditional",
+
       "code": "Variable := (if condition\n    then expression\n    else expression);"
     },
     "while_loop": {
-      "name": "While loop",
+
       "code": "while condition loop\n    statements;\nend loop;"
     },
     "do_while_loop": {
-      "name": "Do/While loop",
+
       "code": "loop\n    statements;\n    exit when not condition;\nend loop;"
     },
     "for_loop": {
-      "name": "For loop",
+
       "code": "for I in First_Index .. Last_Index loop\n    statements;\nend loop;"
     }
   }

--- a/web/thesauruses/ada/data_types.json
+++ b/web/thesauruses/ada/data_types.json
@@ -26,7 +26,7 @@
   },
   "data_types": {
     "boolean": {
-      "name": "Boolean",
+
       "code": "boolean"
     },
     "integer_8_bit": {

--- a/web/thesauruses/csharp/control_structures.json
+++ b/web/thesauruses/csharp/control_structures.json
@@ -30,11 +30,11 @@
     },
     "control_structures": {
       "if_conditional": {
-        "name": "If conditional",
+
         "code": "if (condition)\n{\n     statements;\n}"
       },
       "if_else_conditional": {
-        "name": "If/Else conditional",
+
         "code": "if (condition)\n{\n     statements;\n} \nelse\n{\n     statements;\n}"
       },
       "if_elseif_conditional": {

--- a/web/thesauruses/csharp/data_types.json
+++ b/web/thesauruses/csharp/data_types.json
@@ -28,11 +28,11 @@
   },
   "data_types": {
     "boolean": {
-        "name": "Boolean",
+
         "code": "bool"
     },
     "integer_16_bit": {
-        "name": "16-bit integer",
+
         "code": "short"
     },
     "integer_32_bit": {

--- a/web/thesauruses/csharp/functions.json
+++ b/web/thesauruses/csharp/functions.json
@@ -27,23 +27,23 @@
   },
   "functions": {
     "void_function_no_parameters": {
-      "name": "Function that does not return a value and takes no parameters",
+
       "code": "void FunctionName()\n{\n\t//code\n}"
     },
     "void_function_with_parameters": {
-      "name": "Function that does not return a value and that takes 1 or more defined parameters",
+
       "code": "void FunctionName(parameterType1 parameterName1, parameterType2 parameterName2)\n{\n\t//code\n}"
     },
     "void_function_variable_parameters": {
-      "name": "Function that does not return a value and function that takes an unknown number of parameters",
+
       "code": "void FunctionName(params parameterType[] parameterName)\n{\n//code\n}"
     },
     "return_value_function_no_parameters": {
-      "name": "Function that returns a value and takes no parameters",
+
       "code": "returnValueType FunctionName()\n{\n\t//code\n\treturn returnValue;\n}"
     },
     "return_value_function_with_parameters": {
-      "name": "Function that returns a value and takes 1 or more defined parameters",
+
       "code": "returnValueType FunctionName(parameterType1 parameterName1, parameterType2 parameterName2)\n{\n\t//code\n\treturn returnValue;\n}"
     },
     "return_value_function_variable_parameters": {

--- a/web/thesauruses/haskell/data_types.json
+++ b/web/thesauruses/haskell/data_types.json
@@ -40,11 +40,11 @@
       "code": "Data.Int.Int32"
     },
     "integer_64_bit": {
-      "name": "64-bit integer",
+
       "code": "Data.Int.Int64"
     },
     "integer_as_object": {
-      "name": "Object-based Integer",
+
       "code": "Integer"
     },
     "float_16_bit": {

--- a/web/thesauruses/java/data_types.json
+++ b/web/thesauruses/java/data_types.json
@@ -53,7 +53,7 @@
     },
     "float_16_bit": {
       "name": "16-bit floating point",
-      "code": null
+      "not-implemented": true
     },
     "float_32_bit": {
       "name": "32-bit floating point",
@@ -77,15 +77,15 @@
     },
     "complex_as_object": {
       "name": "Complex Number as an object",
-      "code": null
+      "not-implemented": true
     },
     "real_number_part": {
       "name": "Complex number real part",
-      "code": null
+      "not-implemented": true
     },
     "imaginary_number_part": {
       "name": "Complex number imaginary part",
-      "code": null
+      "not-implemented": true
     }
   }
 }

--- a/web/thesauruses/nim/functions.json
+++ b/web/thesauruses/nim/functions.json
@@ -27,47 +27,47 @@
   },
   "functions": {
     "void_function_no_parameters": {
-      "name": "Function that does not return a value and takes no parameters",
+
       "code": "func name() =\\n  discard"
     },
     "void_function_with_parameters": {
-      "name": "Function that does not return a value and that takes 1 or more defined parameters",
+
       "code": "func name(parameter0: int, parameter1: bool) =\\n  discard"
     },
     "void_function_variable_parameters": {
-      "name": "Function that does not return a value and function that takes an unknown number of parameters",
+
       "code": "func name(parameters: varargs[auto]) =\\n  discard"
     },
     "return_value_function_no_parameters": {
-      "name": "Function that returns a value and takes no parameters",
+
       "code": "func name(): string =\\n  result = \"value\""
     },
     "return_value_function_with_parameters": {
-      "name": "Function that returns a value and takes 1 or more defined parameters",
+
       "code": "func name(parameter0: int, parameter1: bool): string =\\n  result = \"value\""
     },
     "return_value_function_variable_parameters": {
-      "name": "Function that returns a value and takes an unknown number of parameters",
+
       "code": "func name(parameters: varargs[auto]): string =\\n  result = \"value\""
     },
     "anonymous_function_no_parameters": {
-      "name": "Anonymous function that takes no parameters",
+
       "code": "func (): string =\\n  result = \"value\""
     },
     "anonymous_function_with_parameters": {
-      "name": "Anonymous function that takes 1 or more defined parameters",
+
       "code": "func name(parameter0: int, parameter1: int): string =\\n  result = \"value\""
     },
     "anonymous_function_variable_parameters": {
-      "name": "Anonymous function that takes an unknown number of parameters",
+
       "code": "func (parameters: varargs[auto]): string =\\n  result = \"value\""
     },
     "call_subroutine": {
-      "name": "Call subroutine",
+
       "code": "name(parameter0, parameter1, parameterN)"
     },
     "return_from_subroutine": {
-      "name": "Return from subroutine",
+
       "code": "result = \"value\""
     }
   }

--- a/web/thesauruses/python/control_structures.json
+++ b/web/thesauruses/python/control_structures.json
@@ -36,22 +36,22 @@
       "code": "if condition:\n    statements\nelif condition:\n    statements\nelse:\n    statements"
     },
     "ternary_conditional": {
-      "name": "Conditional (ternary) Operator",
+
       "code": "expression_if_true if condition else expression_if_false"
     },
     "while_loop": {
-      "name": "While loop",
+
       "code": "while condition:\n    statements"
     },
     "foreach_loop": {
       "code": "for iterator in iterable:\n    statements"
     },
     "map_iteration": {
-      "name": "Map iteration",
+
       "code": "map(function, iterable)"
     },
     "filter_iteration": {
-      "name": "Filter iteration",
+
       "code": "filter(function, iterable)"
     }
   }

--- a/web/thesauruses/python/data_types.json
+++ b/web/thesauruses/python/data_types.json
@@ -33,15 +33,15 @@
     },
     "integer_16_bit" : {
       "name": "16-bit integer",
-      "code": null
+      "not-implemented": true
     },
     "integer_32_bit": {
       "name": "32-bit integer",
-      "code": null
+      "not-implemented": true
     },
     "integer_64_bit": {
       "name": "64-bit integer",
-      "code": null
+      "not-implemented": true
     },
     "integer_as_object": {
       "name": "Object-based Integer",
@@ -49,15 +49,15 @@
     },
     "float_16_bit": {
       "name": "16-bit floating point",
-      "code": null
+      "not-implemented": true
     },
     "float_32_bit": {
       "name": "32-bit floating point",
-      "code": null
+      "not-implemented": true
     },
     "float_64_bit": {
       "name": "64-bit floating point",
-      "code": null
+      "not-implemented": true
     },
     "float_as_object": {
       "name": "Object-based floating point",
@@ -69,7 +69,7 @@
     },
     "string_as_array": {
       "name": "String as an array",
-      "code": null
+      "not-implemented": true
     },
     "complex_as_object": {
       "name": "Complex Number as an object",

--- a/web/thesauruses/python/functions.json
+++ b/web/thesauruses/python/functions.json
@@ -23,31 +23,31 @@
   },
   "functions": {
     "void_function_no_parameters": {
-      "name": "Function that does not return a value and takes no parameters",
+
       "code": "def function_name():\n    statements"
     },
     "void_function_with_parameters": {
-      "name": "Function that does not return a value and that takes 1 or more defined parameters",
+
       "code": "def function_name(parameter, parameter_1):\n    statements"
     },
     "void_function_variable_parameters": {
-      "name": "Function that does not return a value and function that takes an unknown number of parameters",
+
       "code": "def function_name(*parameter_name):\n    statements"
     },
     "return_value_function_no_parameters": {
-      "name": "Function that returns a value and takes no parameters",
+
       "code": "def function_name():\n    statements\n    return expression"
     },
     "return_value_function_with_parameters": {
-      "name": "Function that returns a value and takes 1 or more defined parameters",
+
       "code": "def function_name(parameter, parameter_1):\n    statements\n    return expression"
     },
     "return_value_function_variable_parameters": {
-      "name": "Function that returns a value and takes an unknown number of parameters",
+
       "code": "def function_name(*parameter_name):\n    statements\n    return expression"
     },
     "anonymous_function_no_parameters": {
-      "name": "Anonymous function that takes no parameters",
+
       "code": "lambda: expression"
     },
     "anonymous_function_with_parameters": {

--- a/web/thesauruses/rust/data_types.json
+++ b/web/thesauruses/rust/data_types.json
@@ -30,11 +30,11 @@
   },
   "data_types": {
     "boolean": {
-      "name": "Boolean",
+
       "code": "bool"
     },
     "integer_8_bit": {
-      "name": "8-bit integer",
+
       "code": "i8"
     },
     "integer_16_bit": {

--- a/web/thesauruses/rust/functions.json
+++ b/web/thesauruses/rust/functions.json
@@ -27,39 +27,39 @@
   },
   "functions": {
     "void_function_no_parameters": {
-      "name": "Function that does not return a value and takes no parameters",
+
       "code": "fn function() {\n    statements;\n}"
     },
     "void_function_with_parameters": {
-      "name": "Function that does not return a value and that takes 1 or more defined parameters",
+
       "code": "fn function(parameter: type, parameter2: type2) {\n    statements;\n}"
     },
     "void_function_variable_parameters": {
-      "name": "Function that does not return a value and function that takes an unknown number of parameters",
+
       "code": ""
     },
     "return_value_function_no_parameters": {
-      "name": "Function that returns a value and takes no parameters",
+
       "code": "fn function() -> return_type {\n    statements;\n    expression\n}"
     },
     "return_value_function_with_parameters": {
-      "name": "Function that returns a value and takes 1 or more defined parameters",
+
       "code": "fn function(parameter: type, parameter2: type2) -> return_type {\n    statements;\n    expression\n}"
     },
     "return_value_function_variable_parameters": {
-      "name": "Function that returns a value and takes an unknown number of parameters",
+
       "code": ""
     },
     "anonymous_function_no_parameters": {
-      "name": "Anonymous function that takes no parameters",
+
       "code": "|| { statements; }"
     },
     "anonymous_function_with_parameters": {
-      "name": "Anonymous function that takes 1 or more defined parameters",
+
       "code": "|parameter, parameter2| { statements; }"
     },
     "anonymous_function_variable_parameters": {
-      "name": "Anonymous function that takes an unknown number of parameters",
+
       "code": ""
     },
     "call_subroutine": {

--- a/web/thesauruses/scala/data_types.json
+++ b/web/thesauruses/scala/data_types.json
@@ -28,39 +28,39 @@
   },
   "data_types": {
     "boolean": {
-      "name": "Boolean",
+
       "code": "Boolean"
     },
     "integer_8_bit": {
-      "name": "8-bit integer",
+
       "code": "Byte"
     },
     "integer_16_bit": {
-      "name": "16-bit integer",
+
       "code": "Short"
     },
     "integer_32_bit": {
-      "name": "32-bit integer",
+
       "code": "Int"
     },
     "integer_64_bit": {
-      "name": "64-bit integer",
+
       "code": "Long"
     },
     "integer_as_object": {
-      "name": "",
-      "code": null
+
+      "not-implemented": true
     },
     "float_16_bit": {
-      "name": "16-bit floating point",
-      "code": null
+
+      "not-implemented": true
     },
     "float_32_bit": {
-      "name": "32-bit floating point",
+
       "code": "Float"
     },
     "float_64_bit": {
-      "name": "64-bit floating point",
+
       "code": "Double"
     },
     "float_as_object": {
@@ -73,19 +73,19 @@
     },
     "string_as_array": {
       "name": "String as an array",
-      "code": null
+      "not-implemented": true
     },
     "complex_as_object": {
       "name": "Complex Number as an object",
-      "code": null
+      "not-implemented": true
     },
     "real_number_part": {
       "name": "Complex number real part",
-      "code": null
+      "not-implemented": true
     },
     "imaginary_number_part": {
       "name": "Complex number imaginary part",
-      "code": null
+      "not-implemented": true
     }
   }
 }

--- a/web/views.py
+++ b/web/views.py
@@ -58,6 +58,11 @@ class Language(object):
                 "code": "",
                 "comment": ""
             }
+        elif self.concepts.get(concept_key).get("not-implemented", False):
+            return {
+                "code": "Not Implemented In Language",
+                "comment": self.concepts.get(concept_key).get("comment", "")
+            }
         else:
             return self.concepts.get(concept_key)
 

--- a/web/views.py
+++ b/web/views.py
@@ -74,7 +74,7 @@ class Language(object):
         return self.concept(concept_key).get("not-implemented", False) is False
 
     def concept_code(self, concept_key):
-        return self.concept(concept_key)["code"]
+        return self.concept(concept_key).get("code")
 
     def concept_comment(self, concept_key):
         return self.concept(concept_key).get("comment", "")
@@ -110,16 +110,23 @@ class MetaStructure(object):
 
 
 def format_code_for_display(concept_key, lang):
-    if lang.concept_unknown(concept_key):
+    if lang.concept_unknown(concept_key) or lang.concept_code(concept_key) is None:
         return "Unknown"
     if lang.concept_implemented(concept_key):
         return highlight(
             lang.concept_code(concept_key),
             get_lexer_by_name(lang.key),
             HtmlFormatter()
-        ) if lang.concept_code(concept_key) else None
+        )
     else:
-        return "Not Implemented"
+        return None
+
+def format_comment_for_display(concept_key, lang):
+    if not lang.concept_implemented(concept_key) and lang.concept_comment(concept_key) == "":
+        return "Not Implemented In This Language"
+    else:
+        return lang.concept_comment(concept_key)
+
 
 def compare(request):
     lang1 = Language(escape(strip_tags(request.GET.get('lang1', ''))))
@@ -165,8 +172,8 @@ def compare(request):
             "name": meta_structure.concepts[concept_key]["name"],
             "code1": format_code_for_display(concept_key, lang1),
             "code2": format_code_for_display(concept_key, lang2),
-            "comment1": lang1.concept_comment(concept_key),
-            "comment2": lang2.concept_comment(concept_key)
+            "comment1": format_comment_for_display(concept_key, lang1),
+            "comment2": format_comment_for_display(concept_key, lang2)
         })
 
     # establish order listing across all languages
@@ -219,7 +226,7 @@ def reference(request):
             "id": concept_key,
             "name": meta_structure.concepts[concept_key]["name"],
             "code": format_code_for_display(concept_key, lang),
-            "comment": lang.concept_comment(concept_key)
+            "comment": format_comment_for_display(concept_key, lang)
         })
 
     response = {


### PR DESCRIPTION
## 📝 What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 📖 Description

This replaces `"code": null` as a somewhat vague way of doing things with `"not-implemented": true` as a way of distinguishing specifically that this code concept does not exist in a language. Along the way, some code has been cleaned up. This also replaces it in every thesaurus file as well.

