### PR TITLE
Fix space after 'Comparing' in the title.

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -181,7 +181,7 @@ def compare(request):
 
     # DB equivalent of full outer join
     response = {
-        "title": "Comparing" + lang1.friendly_name + " " + lang2.friendly_name,
+        "title": "Comparing " + lang1.friendly_name + " " + lang2.friendly_name,
         "concept": meta_structure.key,
         "concept_friendly_name": meta_structure.friendly_name,
         "lang1": lang1.key,


### PR DESCRIPTION
## 📝 What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 📖 Description

The `<title>` for the compare page would be "ComparingRuby and Nim" and this fixes it!

## ✅ QA Instructions, Screenshots

I open the page and look at the title :)
