### PR TITLE
Fix 'add or correct' links.

### DIFF
--- a/web/templates/compare.html
+++ b/web/templates/compare.html
@@ -58,14 +58,14 @@
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang1 }}/{{ concept_id }}.json">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang1 }}/{{ concept }}.json">
                             Want to add or correct information for {{ lang1_friendlyname }}?
                         </a>
                     </div>
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang2 }}/{{ concept_id }}.json">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang2 }}/{{ concept }}.json">
                             Want to add or correct information for {{ lang2_friendlyname }}?
                         </a>
                     </div>

--- a/web/templates/reference.html
+++ b/web/templates/reference.html
@@ -51,7 +51,7 @@
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang }}/{{ concept_id }}.json">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/blob/master/web/thesauruses/{{ lang }}/{{ concept }}.json">
                             Want to add or correct information for {{ lang_friendlyname }}?
                         </a>
                     </div>


### PR DESCRIPTION
The `concept_id` template variable is now just `concept`.

## 📝 What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 📖 Description

The link shown below went to something like `ruby/.json` instead of `ruby/data_types.json`. Now it is fixed.

![image](https://user-images.githubusercontent.com/31674/119073314-0e9b1700-b9bb-11eb-9773-7862ff73f08b.png)

## ✅ QA Instructions, Screenshots

I opened it up and clicked on it and it worked. lmao.

Closes #207