### PR TITLE
Add `startinline=True` so languages like PHP will still get formatted correctly

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -115,7 +115,7 @@ def format_code_for_display(concept_key, lang):
     if lang.concept_implemented(concept_key):
         return highlight(
             lang.concept_code(concept_key),
-            get_lexer_by_name(lang.key),
+            get_lexer_by_name(lang.key, startinline=True),
             HtmlFormatter()
         )
     else:


### PR DESCRIPTION
Fix issue #206 


## 📝 What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 📖 Description

PHP wasn't getting automatically formatted because it lacked the `<?php` needed to detect the language for formatting. This tells it not to try to do that.

## ✅ QA Instructions, Screenshots

Before:
![image](https://user-images.githubusercontent.com/2601974/121101888-b5a8ec80-c7ca-11eb-9e8f-d0ef3e88e2d5.png)

After:
![image](https://user-images.githubusercontent.com/2601974/121101926-c9545300-c7ca-11eb-81f1-aa9171b48053.png)


