### PR TITLE
Issue 242 fix 404 error pages

### DIFF
--- a/web/Language.py
+++ b/web/Language.py
@@ -24,6 +24,13 @@ class Language:
         # Empty string is falsy, but text is truthy, but would return return text
         return bool(self.key)
 
+    def lang_exists(self):
+        """
+        Returns a Boolean if the language (self.key) exists in the thesauruses or not
+        :rtype: bool
+        """
+        return os.path.exists(os.path.join("web", "thesauruses", self.key))
+
     def load_structure(self, structure_key):
         """
         Loads the structure file into the Language object

--- a/web/views.py
+++ b/web/views.py
@@ -179,7 +179,7 @@ def compare(request):
 
 def reference(request):
     """
-    Renders the page showing one language structure for reference (/compare)
+    Renders the page showing one language structure for reference (/reference)
     :param request: HttpRequest object
     :return: HttpResponse object with rendered object of the page
     """

--- a/web/views.py
+++ b/web/views.py
@@ -117,8 +117,15 @@ def compare(request):
         lang1.load_structure(meta_structure.key)
     # pylint: disable=broad-except
     except Exception:
+        error_message = ""
+        if lang1.lang_exists():
+            error_message = f"There is no entry about this structure/concept for the \
+                first language ({lang1.key}) yet.<br />"
+        else:
+            error_message = f"The first language ({lang1.key}) isn't valid. \
+                Double-check your URL and try again.<br />"
         error_page_data = {
-            "message": "The first language (" + lang1.key + ") isn't valid. Double-check your URL and try again.<br />"
+            "message": error_message
         }
         response = render(request, "errormisc.html", error_page_data)
         return HttpResponseNotFound(response)
@@ -127,8 +134,15 @@ def compare(request):
         lang2.load_structure(meta_structure.key)
     # pylint: disable=broad-except
     except Exception:
+        error_message = ""
+        if lang2.lang_exists():
+            error_message = f"There is no entry about this structure/concept for the \
+                second language ({lang2.key}) yet.<br />"
+        else:
+            error_message = f"The second language ({lang2.key}) isn't valid. \
+                Double-check your URL and try again.<br />"
         error_page_data = {
-            "message": "The second language (" + lang2.key + ") isn't valid. Double-check your URL and try again.<br />"
+            "message": error_message
         }
         response = render(request, "errormisc.html", error_page_data)
         return HttpResponseNotFound(response)
@@ -215,8 +229,15 @@ def reference(request):
         lang.load_structure(meta_structure.key)
     # pylint: disable=broad-except
     except Exception:
+        error_message = ""
+        if lang.lang_exists():
+            error_message = f"There is no entry about this structure/concept for the \
+                language ({lang.key}) yet.<br />"
+        else:
+            error_message = f"The language ({lang.key}) isn't valid. \
+                Double-check your URL and try again.<br />"
         error_page_data = {
-            "message": "The language (" + lang.key + ") isn't valid. Double-check your URL and try again.<br />"
+            "message": error_message
         }
         response = render(request, "errormisc.html", error_page_data)
         return HttpResponseNotFound(response)


### PR DESCRIPTION
## 📝 What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 📖 Description

Fixes #242

Adds a new method `lang_exists` to the Language class, that checks if the path for the language exists in the thesauruses folder.
Uses this method to determine if a language exists, if so a different error message is displayed.

## ✅ QA Instructions, Screenshots

Modify the lang parameters in the urls for /compare and /reference:
* Same behavior as before when the language does not exist.
* New error message if the language exists but doesn't have an entry for the concept.

