### PR TITLE
Add strings concept meta file

### DIFF
--- a/web/thesauruses/_meta/strings.json
+++ b/web/thesauruses/_meta/strings.json
@@ -1,0 +1,336 @@
+{
+  "meta": {
+    "language": "language_id",
+    "language_version": "version.number",
+    "language_name": "Human-Friendly Language Name"
+  },
+  "categories": {
+    "Creating/Destroying Strings": [
+      "is_primitive_or_not",
+      "import",
+      "default_string_byte_encoding",
+      "create_new_string",
+      "create_multiline_string",
+      "assign_new_string",
+      "destroy_string"
+    ],
+    "String Basics": [
+      "length_of_string",
+      "max_length_of_string",
+      "clear_string",
+      "is_empty",
+      "concatenate_two_strings",
+      "concatenate_many_strings",
+      "is_all_alphabetical",
+      "is_all_numerical",
+      "is_all_alphanumeric",
+      "is_decimal",
+      "is_all_whitespaces",
+      "is_all_uppercase",
+      "is_all_lowercase",
+      "is_in_titlecase"
+    ],
+    "Find and Search": [
+      "does_substring_exist",
+      "find_start_index_of_substring",
+      "find_start_index_of_additional_substring",
+      "find_start_index_of_substring_from_end",
+      "count_occurrences_of_substring",
+      "get_leftmost_characters",
+      "get_rightmost_characters",
+      "get_substring_from_start_and_end_index",
+      "get_substring_from_start_index_and_length"
+    ],
+    "Manipulating Strings": [
+      "convert_to_uppercase",
+      "convert_to_lowercase",
+      "convert_to_title_case",
+      "capitalize_string",
+      "remove_whitespace",
+      "replace_substring",
+      "replace_all_substring",
+      "split_at_index",
+      "split_at_newlines",
+      "split_at_substring",
+      "merge_lists_into_string",
+      "encode_html_entities",
+      "decode_html_entities",
+      "encode_url_percent",
+      "decode_url_percent",
+      "encode_to_base64",
+      "decode_from_base64"
+    ],
+    "String Formatting": [
+      "format_string_function",
+      "parameter_format_in_order",
+      "parameter_format_numerical",
+      "parameter_format_by_name",
+      "format_as_integer",
+      "format_as_decimal",
+      "format_as_fixed_decimal",
+      "format_as_currency",
+      "format_as_percentage",
+      "format_number_with_separators",
+      "format_number_with_positive_negative_sign",
+      "format_number_in_scientific_notation_little_e",
+      "format_number_in_scientific_notation_big_e",
+      "format_number_in_binary",
+      "format_number_in_octal",
+      "format_number_in_hexadecimal"
+    ]
+  },
+  "strings": {
+    "is_primitive_or_not": {
+      "name": "Is this a built-in type in this language?",
+      "code": ""
+    },
+    "import": {
+      "name": "Import the string class",
+      "code": ""
+    },
+    "default_string_byte_encoding": {
+      "name": "Default byte encoding (ex: ASCII, UTF-8, UTF-16, etc.)",
+      "code": ""
+    },
+    "create_new_string": {
+      "name": "Create new string",
+      "code": ""
+    },
+    "create_multiline_string": {
+      "name": "Create new multi-line string",
+      "code": ""
+    },
+    "assign_new_string": {
+      "name": "Assign string from another string",
+      "code": ""
+    },
+    "destroy_string": {
+      "name": "Destroy string",
+      "code": ""
+    },
+    "length_of_string": {
+      "name": "Length of string",
+      "code": ""
+    },
+    "max_length_of_string": {
+      "name": "Maximum length of string",
+      "code": ""
+    },
+    "clear_string": {
+      "name": "Clear/empty string",
+      "code": ""
+    },
+    "is_empty": {
+      "name": "Is string empty?",
+      "code": ""
+    },
+    "concatenate_two_strings": {
+      "name": "Concatenate/join two strings",
+      "code": ""
+    },
+    "concatenate_many_strings": {
+      "name": "Concatenate/join many strings",
+      "code": ""
+    },
+    "is_all_alphabetical": {
+      "name": "Is string all alphabetical characters?",
+      "code": ""
+    },
+    "is_all_numerical": {
+      "name": "Is string all numerical characters?",
+      "code": ""
+    },
+    "is_all_alphanumeric": {
+      "name": "Is string all alphanumeric characters?",
+      "code": ""
+    },
+    "is_decimal": {
+      "name": "Is string a decimal number?",
+      "code": ""
+    },
+    "is_all_whitespaces": {
+      "name": "Is string all whitespace characters?",
+      "code": ""
+    },
+    "is_all_uppercase": {
+      "name": "Is string all uppercase characters?",
+      "code": ""
+    },
+    "is_all_lowercase": {
+      "name": "Is string all lowercase characters?",
+      "code": ""
+    },
+    "is_in_titlecase": {
+      "name": "Is string formatted in title case?",
+      "code": ""
+    },
+    "does_substring_exist": {
+      "name": "Does a substring exist in a string?",
+      "code": ""
+    },
+    "find_start_index_of_substring": {
+      "name": "Find index of where a substring starts",
+      "code": ""
+    },
+    "find_start_index_of_additional_substring": {
+      "name": "Find index of an additional substring (or starting at another index)",
+      "code": ""
+    },
+    "find_start_index_of_substring_from_end": {
+      "name": "Find substring index starting at end",
+      "code": ""
+    },
+    "count_occurrences_of_substring": {
+      "name": "Find number of occurences of a substring",
+      "code": ""
+    },
+    "get_leftmost_characters": {
+      "name": "Get a specified number of characters from the left",
+      "code": ""
+    },
+    "get_rightmost_characters": {
+      "name": "Get a specified number of characters from the right",
+      "code": ""
+    },
+    "get_substring_from_start_and_end_index": {
+      "name": "Return a substring from a string based on starting and ending indices",
+      "code": ""
+    },
+    "get_substring_from_start_index_and_length": {
+      "name": "Return a substring from a string based on starting index and size of substring",
+      "code": ""
+    },
+    "convert_to_uppercase": {
+      "name": "Convert string to all uppercase",
+      "code": ""
+    },
+    "convert_to_lowercase": {
+      "name": "Convert string to all lowercase",
+      "code": ""
+    },
+    "convert_to_title_case": {
+      "name": "Convert string to title case",
+      "code": ""
+    },
+    "capitalize_string": {
+      "name": "Capitalize first letter of a string",
+      "code": ""
+    },
+    "remove_whitespace": {
+      "name": "Remove all whitespaces from string",
+      "code": ""
+    },
+    "replace_substring": {
+      "name": "Replace a substring with another string",
+      "code": ""
+    },
+    "replace_all_substring": {
+      "name": "Replace all substring matches with another string",
+      "code": ""
+    },
+    "split_at_index": {
+      "name": "Split string into a list of strings at a given index",
+      "code": ""
+    },
+    "split_at_newlines": {
+      "name": "Split string into a list of strings at every new line character",
+      "code": ""
+    },
+    "split_at_substring": {
+      "name": "Split string by locating all substrings",
+      "code": ""
+    },
+    "merge_lists_into_string": {
+      "name": "Merge a list of strings into one string",
+      "code": ""
+    },
+    "encode_html_entities": {
+      "name": "Encode HTML entities in a string (ex: ™ to &trade;)",
+      "code": ""
+    },
+    "decode_html_entities": {
+      "name": "Decode HTML entitles into characters",
+      "code": ""
+    },
+    "encode_url_percent": {
+      "name": "Encode URL percent encoding into string (ex: ' ' to %20)",
+      "code": ""
+    },
+    "decode_url_percent": {
+      "name": "Decode URL percent encoding",
+      "code": ""
+    },
+    "encode_to_base64": {
+      "name": "Encode string into Base64 format",
+      "code": ""
+    },
+    "decode_from_base64": {
+      "name": "Decode string from Base64 format",
+      "code": ""
+    },
+    "format_string_function": {
+      "name": "Function to format a string",
+      "code": ""
+    },
+    "parameter_format_in_order": {
+      "name": "Parameter used in format function if they're used in order",
+      "code": ""
+    },
+    "parameter_format_numerical": {
+      "name": "Parameter used in format function if they're numerically numbered",
+      "code": ""
+    },
+    "parameter_format_by_name": {
+      "name": "Paramater used in format function if they're named variables",
+      "code": ""
+    },
+    "format_as_integer": {
+      "name": "Format parameter as an integer",
+      "code": ""
+    },
+    "format_as_decimal": {
+      "name": "Format parameter as a decimal number",
+      "code": ""
+    },
+    "format_as_fixed_decimal": {
+      "name": "Format parameter as a fixed-point decimal number",
+      "code": ""
+    },
+    "format_as_currency": {
+      "name": "Format parameter as a currency number",
+      "code": ""
+    },
+    "format_as_percentage": {
+      "name": "Format parameter as a percentage number",
+      "code": ""
+    },
+    "format_number_with_separators": {
+      "name": "Format number with thousand separators",
+      "code": ""
+    },
+    "format_number_with_positive_negative_sign": {
+      "name": "Format number with positive/negative signs",
+      "code": ""
+    },
+    "format_number_in_scientific_notation_little_e": {
+      "name": "Format number with scientific notation with 'e'",
+      "code": ""
+    },
+    "format_number_in_scientific_notation_big_e": {
+      "name": "Format number with scientific notation with 'E'",
+      "code": ""
+    },
+    "format_number_in_binary": {
+      "name": "Format number into binary",
+      "code": ""
+    },
+    "format_number_in_octal": {
+      "name": "Format number into octal",
+      "code": ""
+    },
+    "format_number_in_hexadecimal": {
+      "name": "Format number into hexadecimal",
+      "code": ""
+    }
+  }
+}

--- a/web/thesauruses/meta_info.json
+++ b/web/thesauruses/meta_info.json
@@ -22,6 +22,7 @@
     "Data Types": "data_types",
     "Functions, Methods, and Subroutines": "functions",
     "Lists, Arrays, and Hashed Lists": "lists",
-    "Logical and Mathematical/Arithmetic Operators": "operators"
+    "Logical and Mathematical/Arithmetic Operators": "operators",
+    "Strings": "strings"
   }
 }


### PR DESCRIPTION
Closes #254 

## 📝 What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 📖 Description

This adds "strings" to the list of concepts on the main page. (This does not add strings to any of the languages yet.)

## ✅ QA Instructions, Screenshots

It should show "Strings" in the dropdown on the home page for both reference and compare sections.

