### PR TITLE
Added Objective-C Data Types

### DIFF
--- a/web/thesauruses/meta_info.json
+++ b/web/thesauruses/meta_info.json
@@ -9,6 +9,7 @@
     "Java (version 15)": "java",
     "JavaScript (version ES2020)": "javascript",
     "Nim (version 1.4)": "nim",
+    "Objective-C": "objectivec",
     "PHP (version 7.4)": "php",
     "Python (version 3.7)": "python",
     "Ruby (version 3.0)": "ruby",

--- a/web/thesauruses/meta_info.json
+++ b/web/thesauruses/meta_info.json
@@ -9,7 +9,7 @@
     "Java (version 15)": "java",
     "JavaScript (version ES2020)": "javascript",
     "Nim (version 1.4)": "nim",
-    "Objective-C": "objectivec",
+    "Objective-C (version 2.0)": "objectivec",
     "PHP (version 7.4)": "php",
     "Python (version 3.7)": "python",
     "Ruby (version 3.0)": "ruby",

--- a/web/thesauruses/objectivec/data_types.json
+++ b/web/thesauruses/objectivec/data_types.json
@@ -2,7 +2,7 @@
    "meta": {
      "language": "language_id",
      "language_version": "version.number",
-     "language_name": "Human-Friendly Language Name"
+     "language_name": "Objective-C"
    },
    "categories": {
      "Numerical": [

--- a/web/thesauruses/objectivec/data_types.json
+++ b/web/thesauruses/objectivec/data_types.json
@@ -50,30 +50,31 @@
      },
      "signed_integer_16_bit": {
        "code": "short int",
-       "comment": "Signed short integers range from -32768 to 32767"
+       "comment": "Signed short integers range from -32768 to 32767."
      },
      "unsigned_integer_16_bit": {
        "code": "unsigned short int",
-       "comment": "Unsigned short integers range from 0 to 65535"
+       "comment": "Unsigned short integers range from 0 to 65535."
      },
      "signed_integer_32_bit": {
        "code": "int",
-       "comment": "Integers range from -2147483648 to 2147483647"
+       "comment": "Integers range from -2147483648 to 2147483647."
      },
      "unsigned_integer_32_bit": {
        "code": "unsigned int",
-       "comment": "Unsigned integers range from 0 to 4294967295"
+       "comment": "Unsigned integers range from 0 to 4294967295."
      },
      "signed_integer_64_bit": {
        "code": "long int",
-       "comment": "Long integers range from -9223372036854775808 to 9223372036854775807"
+       "comment": "Long integers range from -9223372036854775808 to 9223372036854775807."
      },
      "unsigned_integer_64_bit": {
        "code": "unsigned long int",
-       "comment": "Unsigned long integers range from 0 to 18446744073709551615"
+       "comment": "Unsigned long integers range from 0 to 18446744073709551615."
      },
      "signed_integer_as_object": {
-      "not-implemented": true
+      "code": "NSNumber",
+      "comment": "NSNumber can store any integer, float, or double. However, it is not commonly used to store floats or doubles because it has a subclass called NSDecimalNumber, which is more precise."
      },
      "unsigned_integer_as_object": {
       "not-implemented": true
@@ -86,19 +87,21 @@
      },
      "signed_float_32_bit": {
        "code": "float",
-       "comment": "The f suffix denotes the end decimal."
+       "comment": "Floats in Objective-C are precise up to 7 digits."
      },
      "unsigned_float_32_bit": {
       "not-implemented": true
      },
      "signed_float_64_bit": {
-      "not-implemented": true
+      "code": "double",
+      "comment": "Doubles in Objective-C are precise up to 15 digits."
      },
      "unsigned_float_64_bit": {
       "not-implemented": true
      },
      "signed_float_as_object": {
-      "not-implemented": true
+      "code": "NSDecimalNumber",
+      "comment": "NSDecimalNumber is often used in situations when precision is key, such as storing a user's bank balance."
      },
      "unsigned_float_as_object": {
       "not-implemented": true

--- a/web/thesauruses/objectivec/data_types.json
+++ b/web/thesauruses/objectivec/data_types.json
@@ -39,104 +39,90 @@
    },
    "data_types": {
      "boolean": {
-       "name": "Boolean",
-       "code": ""
+       "code": "BOOL",
+       "comment": "As opposed to true and false, Objective-C stores boolean values as YES and NO, respectively."
      },
      "signed_integer_8_bit": {
-       "name": "Signed 8-bit integer",
-       "code": ""
+       "not-implemented": true
      },
      "unsigned_integer_8_bit": {
-       "name": "Unsigned 8-bit integer",
-       "code": ""
+      "not-implemented": true
      },
      "signed_integer_16_bit": {
-       "name": "Signed 16-bit integer",
-       "code": ""
+       "code": "short int",
+       "comment": "Signed short integers range from -32768 to 32767"
      },
      "unsigned_integer_16_bit": {
-       "name": "Unsigned 16-bit integer",
-       "code": ""
+       "code": "unsigned short int",
+       "comment": "Unsigned short integers range from 0 to 65535"
      },
      "signed_integer_32_bit": {
-       "name": "Signed 32-bit integer",
-       "code": ""
+       "code": "int",
+       "comment": "Integers range from -2147483648 to 2147483647"
      },
      "unsigned_integer_32_bit": {
-       "name": "Unsigned 32-bit integer",
-       "code": ""
+       "code": "unsigned int",
+       "comment": "Unsigned integers range from 0 to 4294967295"
      },
      "signed_integer_64_bit": {
-       "name": "Signed 64-bit integer",
-       "code": ""
+       "code": "long int",
+       "comment": "Long integers range from -9223372036854775808 to 9223372036854775807"
      },
      "unsigned_integer_64_bit": {
-       "name": "Unsigned 64-bit integer",
-       "code": ""
+       "code": "unsigned long int",
+       "comment": "Unsigned long integers range from 0 to 18446744073709551615"
      },
      "signed_integer_as_object": {
-       "name": "Signed object-based Integer",
-       "code": ""
+      "not-implemented": true
      },
      "unsigned_integer_as_object": {
-       "name": "Unsigned object-based Integer",
-       "code": ""
+      "not-implemented": true
      },
      "signed_float_16_bit": {
-       "name": "Signed 16-bit floating point",
-       "code": ""
+      "not-implemented": true
      },
      "unsigned_float_16_bit": {
-       "name": "Unsigned 16-bit floating point",
-       "code": ""
+      "not-implemented": true
      },
      "signed_float_32_bit": {
-       "name": "Signed 32-bit floating point",
-       "code": ""
+       "code": "float",
+       "comment": "The f suffix denotes the end decimal."
      },
      "unsigned_float_32_bit": {
-       "name": "Unsigned 32-bit floating point",
-       "code": ""
+      "not-implemented": true
      },
      "signed_float_64_bit": {
-       "name": "Signed 64-bit floating point",
-       "code": ""
+      "not-implemented": true
      },
      "unsigned_float_64_bit": {
-       "name": "Unsigned 64-bit floating point",
-       "code": ""
+      "not-implemented": true
      },
      "signed_float_as_object": {
-       "name": "Signed object-based floating point",
-       "code": ""
+      "not-implemented": true
      },
      "unsigned_float_as_object": {
-       "name": "Unsigned object-based floating point",
-       "code": ""
+      "not-implemented": true
      },
      "character": {
-       "name": "Character",
-       "code": ""
+       "code": "char",
+       "comment": "Using %c to output the character value and %i to output the ASCII value."
      },
      "string_as_object": {
-       "name": "String as an object",
-       "code": ""
+       "code": "NSString",
+       "comment": "NSString is immutable, however, Objective-C has a mutable string object called NSMutableString"
      },
      "string_as_array": {
-       "name": "String as an array of characters",
-       "code": ""
+      "code": "NSString",
+      "comment": "NSString is built on the C version of strings, which are arrays of characters. When using an NSString, you can use index notation to access specific characters."
      },
      "complex_as_object": {
-       "name": "Complex Number as an object",
-       "code": ""
+      "not-implemented": true
      },
      "real_number_part": {
-       "name": "Complex number real part",
-       "code": ""
+      "not-implemented": true
      },
      "imaginary_number_part": {
-       "name": "Complex number imaginary part",
-       "code": ""
+      "not-implemented": true
      }
    }
  }

--- a/web/thesauruses/objectivec/data_types.json
+++ b/web/thesauruses/objectivec/data_types.json
@@ -1,0 +1,143 @@
+{
+   "meta": {
+     "language": "language_id",
+     "language_version": "version.number",
+     "language_name": "Human-Friendly Language Name"
+   },
+   "categories": {
+     "Numerical": [
+       "boolean",
+       "signed_integer_8_bit",
+       "unsigned_integer_8_bit",
+       "signed_integer_16_bit",
+       "unsigned_integer_16_bit",
+       "signed_integer_32_bit",
+       "unsigned_integer_32_bit",
+       "signed_integer_64_bit",
+       "unsigned_integer_64_bit",
+       "signed_integer_as_object",
+       "unsigned_integer_as_object",
+       "signed_float_16_bit",
+       "unsigned_float_16_bit",
+       "signed_float_32_bit",
+       "unsigned_float_32_bit",
+       "signed_float_64_bit",
+       "unsigned_float_64_bit",
+       "signed_float_as_object",
+       "unsigned_float_as_object"
+     ],
+     "Characters and Strings": [
+       "character",
+       "string_as_object",
+       "string_as_array"
+     ],
+     "Complex Numbers": [
+       "complex_as_object",
+       "real_number_part",
+       "imaginary_number_part"
+     ]
+   },
+   "data_types": {
+     "boolean": {
+       "name": "Boolean",
+       "code": ""
+     },
+     "signed_integer_8_bit": {
+       "name": "Signed 8-bit integer",
+       "code": ""
+     },
+     "unsigned_integer_8_bit": {
+       "name": "Unsigned 8-bit integer",
+       "code": ""
+     },
+     "signed_integer_16_bit": {
+       "name": "Signed 16-bit integer",
+       "code": ""
+     },
+     "unsigned_integer_16_bit": {
+       "name": "Unsigned 16-bit integer",
+       "code": ""
+     },
+     "signed_integer_32_bit": {
+       "name": "Signed 32-bit integer",
+       "code": ""
+     },
+     "unsigned_integer_32_bit": {
+       "name": "Unsigned 32-bit integer",
+       "code": ""
+     },
+     "signed_integer_64_bit": {
+       "name": "Signed 64-bit integer",
+       "code": ""
+     },
+     "unsigned_integer_64_bit": {
+       "name": "Unsigned 64-bit integer",
+       "code": ""
+     },
+     "signed_integer_as_object": {
+       "name": "Signed object-based Integer",
+       "code": ""
+     },
+     "unsigned_integer_as_object": {
+       "name": "Unsigned object-based Integer",
+       "code": ""
+     },
+     "signed_float_16_bit": {
+       "name": "Signed 16-bit floating point",
+       "code": ""
+     },
+     "unsigned_float_16_bit": {
+       "name": "Unsigned 16-bit floating point",
+       "code": ""
+     },
+     "signed_float_32_bit": {
+       "name": "Signed 32-bit floating point",
+       "code": ""
+     },
+     "unsigned_float_32_bit": {
+       "name": "Unsigned 32-bit floating point",
+       "code": ""
+     },
+     "signed_float_64_bit": {
+       "name": "Signed 64-bit floating point",
+       "code": ""
+     },
+     "unsigned_float_64_bit": {
+       "name": "Unsigned 64-bit floating point",
+       "code": ""
+     },
+     "signed_float_as_object": {
+       "name": "Signed object-based floating point",
+       "code": ""
+     },
+     "unsigned_float_as_object": {
+       "name": "Unsigned object-based floating point",
+       "code": ""
+     },
+     "character": {
+       "name": "Character",
+       "code": ""
+     },
+     "string_as_object": {
+       "name": "String as an object",
+       "code": ""
+     },
+     "string_as_array": {
+       "name": "String as an array of characters",
+       "code": ""
+     },
+     "complex_as_object": {
+       "name": "Complex Number as an object",
+       "code": ""
+     },
+     "real_number_part": {
+       "name": "Complex number real part",
+       "code": ""
+     },
+     "imaginary_number_part": {
+       "name": "Complex number imaginary part",
+       "code": ""
+     }
+   }
+ }
+ 


### PR DESCRIPTION
## What GitHub issue does this PR apply to?
Resolves issue #90.

## What changed and why?

Added Objective-C to the list of languages available and added data types information to `objectivec` directory.

## (If editing Django app) Please add screenshots

Here is the final result!

<img width="1368" alt="objc-data-types-page" src="https://user-images.githubusercontent.com/17087389/135940715-5c2b04ae-021d-4b94-bfc9-99b70a02623e.png">

## Any additional comments or things to be aware of while reviewing?

Objective-C was not in the list of languages when I started work on this issue so I added it. I am about 99.9% sure that I added it where I should have.

<!-- -------------------------- -->
<!-- Don't edit below this line -->
## Reviewer Steps

- [x] Review commits
- [x] (If needed) Approve first run of workflow
- [x] (If needed) Activate Deploy Preview app
- [x] Verify any changes in Deploy Preview
- [x] Approve and/or merge changes
