### PR TITLE
Add Markdown support on comments

### DIFF
--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'markdownify.apps.MarkdownifyConfig',
 ]
 
 MIDDLEWARE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ astroid==2.6.6
 colorama==0.4.4
 dj-database-url==0.5.0
 Django==3.2.6
+django-markdownify==0.9.0
 django-on-heroku==1.1.2
 gunicorn==20.1.0
 isort==5.9.3

--- a/web/templates/comparecard.html
+++ b/web/templates/comparecard.html
@@ -1,3 +1,5 @@
+{% load markdownify %}
+
 <div class="card">
     <div class="card-body">
     {% if code %}
@@ -5,7 +7,7 @@
     {% endif %}
     {% if comment %}
         <div>
-                {{ comment }}
+            {{ comment|markdownify }}
         </div>
     {% endif %}
     </div>

--- a/web/tests/test_templates.py
+++ b/web/tests/test_templates.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+from django.template.loader import render_to_string
+
+
+class TestTemplates(TestCase):
+
+    def test_comparecard(self):
+        # no code and no comment
+        rendered_template_1 = render_to_string("comparecard.html", {}).strip()
+        self.assertEquals(
+            rendered_template_1,
+            "<div class=\"card\">\n"
+            "    <div class=\"card-body\">\n"
+            "    \n"
+            "    \n"
+            "    </div>\n"
+            "</div>"
+        )
+
+        # code (marked as safe), no comment
+        rendered_template_2 = render_to_string(
+            "comparecard.html", {"code": "<b>I am bold!</b>"}
+        ).strip()
+        self.assertEquals(
+            rendered_template_2,
+            "<div class=\"card\">\n"
+            "    <div class=\"card-body\">\n"
+            "    \n"
+            "        <div class=\"syntax\"><b>I am bold!</b></div>\n"
+            "    \n"
+            "    \n"
+            "    </div>\n"
+            "</div>"
+        )
+
+        # no code, comment (with markdown format)
+        rendered_template_3 = render_to_string(
+            "comparecard.html", {"comment": "I am **bold** and *italic*, `let x = 1`."}
+        ).strip()
+        self.assertEquals(
+            rendered_template_3,
+            "<div class=\"card\">\n"
+            "    <div class=\"card-body\">\n"
+            "    \n"
+            "    \n"
+            "        <div>\n"
+            "            I am <strong>bold</strong> and <em>italic</em>, <code>let x = 1</code>.\n"
+            "        </div>\n"
+            "    \n"
+            "    </div>\n"
+            "</div>"
+        )
+
+        # code and comment
+        rendered_template_4 = render_to_string(
+            "comparecard.html",
+            {
+                "code": "<b>I am bold!</b>",
+                "comment": "I am **bold** and *italic*, `let x = 1`."
+            }
+        ).strip()
+        self.assertEquals(
+            rendered_template_4,
+            "<div class=\"card\">\n"
+            "    <div class=\"card-body\">\n"
+            "    \n"
+            "        <div class=\"syntax\"><b>I am bold!</b></div>\n"
+            "    \n"
+            "    \n"
+            "        <div>\n"
+            "            I am <strong>bold</strong> and <em>italic</em>, <code>let x = 1</code>.\n"
+            "        </div>\n"
+            "    \n"
+            "    </div>\n"
+            "</div>"
+        )


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Resolves #213 

## What changed and why?

This Pull Request introduces a new dependency to the project, [django-markdownify](https://django-markdownify.readthedocs.io/en/latest/), and uses its filter in order to parse and properly display Markdown in comments in the `commentcard.html` template.

There's also a new `test_templates.py` file that includes some unit tests to ensure that the `commentcard.html` template is being rendered properly with these changes (and generally speaking). This file can be enhanced with other test cases / test functions for other templates, if needed.

## (If editing Django app) Please add screenshots

<img width="575" alt="Screen Shot 2021-10-04 at 10 00 23 PM" src="https://user-images.githubusercontent.com/26191851/135948478-250453f2-2162-4e5c-8357-098dc9eb8927.png">

This is how the reference for Scala is rendered, showing one of the comments that already has (previously un-parsed) Markdown formatting. You can reach this page by going to `/reference/?concept=functions&lang=scala` ([link to live website](https://codethesaur.us/reference/?concept=functions&lang=scala))

## Any additional comments or things to be aware of while reviewing?

Just noting that I chose to go with a Python solution (instead of parsing Markdown on the client side) to have it done during server side rendering, but I can explore other alternatives if needed! Let me know if there's anything else I can do to improve this PR and this feature :-)


<!-- -------------------------- -->
<!-- Don't edit below this line -->
## Reviewer Steps

- [x] Review commits
- [x] (If needed) Approve first run of workflow
- [x] (If needed) Activate Deploy Preview app
- [x] Verify any changes in Deploy Preview
- [x] Approve and/or merge changes
