### PR TITLE
Updated c# control structures.

### DIFF
--- a/web/thesauruses/csharp/control_structures.json
+++ b/web/thesauruses/csharp/control_structures.json
@@ -31,35 +31,27 @@
   },
   "control_structures": {
     "if_conditional": {
-      "name": "If conditional",
       "code": "if (condition)\n{\n     statements;\n}"
     },
     "if_else_conditional": {
-      "name": "If/Else conditional",
       "code": "if (condition)\n{\n     statements;\n} \nelse\n{\n     statements;\n}"
     },
     "if_elseif_conditional": {
-      "name": "If/ElseIf conditional",
       "code": "if (condition)\n{\n    statements;\n} \nelse if (condition)\n{\n    statements;\n}"
     },
     "if_elseif_else_conditional": {
-      "name": "If/ElseIf/Else conditional",
       "code": "if (condition)\n{\n    statements;\n} \nelse if (condition)\n{\n    statements;\n}\nelse\n{\n    statements;\n}"
     },
     "switch_statement": {
-      "name": "Switch statement",
       "code": "switch (expression)\n{\n    case x:\n        statements;\n        break;\n    case y:\n        statements;\n        break;\n    default:\n        statements;\n        break;\n}"
     },
     "ternary_conditional": {
-      "name": "Ternary conditional",
       "code": "condition ? trueExpression : falseExpression"
     },
     "while_loop": {
-      "name": "While loop",
       "code": "while (condition)\n{\n    statements;\n}"
     },
     "do_while_loop": {
-      "name": "Do/While loop",
       "code": "do\n{\n    statements;\n}\nwhile(condition)"
     },
     "until_loop": {
@@ -69,15 +61,12 @@
       "not-implemented": true
     },
     "for_loop": {
-      "name": "For loop",
       "code": "for(variables; conditions; expressionAfterIteration)\n{\n    statements;\n}"
     },
     "foreach_loop": {
-      "name": "Foreach loop",
       "code": "foreach(item in object)\n{\n    statements;\n}"
     },
     "list_comprehension": {
-      "name": "List Comprehension",
       "code": "var newList = list.Select(x => function(x));",
       "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
@@ -85,17 +74,14 @@
       "not-implemented": true
     },
     "map_iteration": {
-      "name": "Map iteration",
       "code": "var newList = list.Select(x => function(x));",
       "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
     "filter_iteration": {
-      "name": "Filter iteration",
       "code": "var newList = list.Where(x => condition);",
       "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
     "fold_iteration": {
-      "name": "Fold iteration",
       "code": "var result = list.Aggregate((x, y) => expression)",
       "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     }

--- a/web/thesauruses/csharp/control_structures.json
+++ b/web/thesauruses/csharp/control_structures.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "language": "language_id",
-    "language_version": "version.number",
+    "language": "csharp",
+    "language_version": "9.0",
     "language_name": "C#"
   },
   "categories": {
@@ -10,6 +10,7 @@
       "if_else_conditional",
       "if_elseif_conditional",
       "if_elseif_else_conditional",
+      "switch_statement",
       "ternary_conditional"
     ],
     "Loops": [
@@ -18,7 +19,8 @@
       "until_loop",
       "do_until_loop",
       "for_loop",
-      "foreach_loop"
+      "foreach_loop",
+      "list_comprehension"
     ],
     "Iterations": [
       "each_iteration",
@@ -29,9 +31,11 @@
   },
   "control_structures": {
     "if_conditional": {
+      "name": "If conditional",
       "code": "if (condition)\n{\n     statements;\n}"
     },
     "if_else_conditional": {
+      "name": "If/Else conditional",
       "code": "if (condition)\n{\n     statements;\n} \nelse\n{\n     statements;\n}"
     },
     "if_elseif_conditional": {
@@ -41,6 +45,10 @@
     "if_elseif_else_conditional": {
       "name": "If/ElseIf/Else conditional",
       "code": "if (condition)\n{\n    statements;\n} \nelse if (condition)\n{\n    statements;\n}\nelse\n{\n    statements;\n}"
+    },
+    "switch_statement": {
+      "name": "Switch statement",
+      "code": "switch (expression)\n{\n    case x:\n    \nstatements;    break;\n    case y:\n    \nstatements;    break;\n    default:\n    \nstatements;    break;\n}"
     },
     "ternary_conditional": {
       "name": "Ternary conditional",
@@ -54,29 +62,42 @@
       "name": "Do/While loop",
       "code": "do\n{\n    statements;\n}\nwhile(condition)"
     },
+    "until_loop": {
+      "not-implemented": true
+    },
+    "do_until_loop": {
+      "not-implemented": true
+    },
     "for_loop": {
       "name": "For loop",
-      "code": "for(variables; conditions; expression after iteration)\n{\n    statements\n}"
+      "code": "for(variables; conditions; expression after iteration)\n{\n    statements;\n}"
     },
     "foreach_loop": {
       "name": "Foreach loop",
-      "code": "foreach(item in object)\n{\n    statements\n}"
+      "code": "foreach(item in object)\n{\n    statements;\n}"
+    },
+    "list_comprehension": {
+      "name": "List Comprehension",
+      "code": "var newList = list.Select(function);",
+      "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
     "each_iteration": {
-      "name": "Each iteration",
-      "code": ""
+      "not-implemented": true
     },
     "map_iteration": {
       "name": "Map iteration",
-      "code": ""
+      "code": "var newList = list.Select(x => function(x));",
+      "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
     "filter_iteration": {
       "name": "Filter iteration",
-      "code": ""
+      "code": "var newList = list.Where(x => condition);",
+      "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
     "fold_iteration": {
       "name": "Fold iteration",
-      "code": ""
+      "code": "var result = list.Aggregate((x, y) => expression)",
+      "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     }
   }
 }

--- a/web/thesauruses/csharp/control_structures.json
+++ b/web/thesauruses/csharp/control_structures.json
@@ -78,7 +78,7 @@
     },
     "list_comprehension": {
       "name": "List Comprehension",
-      "code": "var newList = list.Select(function);",
+      "code": "var newList = list.Select(x => function(x));",
       "comment": "Requires use of the System.Linq namespace in the System.Core assembly."
     },
     "each_iteration": {

--- a/web/thesauruses/csharp/control_structures.json
+++ b/web/thesauruses/csharp/control_structures.json
@@ -48,7 +48,7 @@
     },
     "switch_statement": {
       "name": "Switch statement",
-      "code": "switch (expression)\n{\n    case x:\n    \nstatements;    break;\n    case y:\n    \nstatements;    break;\n    default:\n    \nstatements;    break;\n}"
+      "code": "switch (expression)\n{\n    case x:\n        statements;\n        break;\n    case y:\n        statements;\n        break;\n    default:\n        statements;\n        break;\n}"
     },
     "ternary_conditional": {
       "name": "Ternary conditional",

--- a/web/thesauruses/csharp/control_structures.json
+++ b/web/thesauruses/csharp/control_structures.json
@@ -70,7 +70,7 @@
     },
     "for_loop": {
       "name": "For loop",
-      "code": "for(variables; conditions; expression after iteration)\n{\n    statements;\n}"
+      "code": "for(variables; conditions; expressionAfterIteration)\n{\n    statements;\n}"
     },
     "foreach_loop": {
       "name": "Foreach loop",


### PR DESCRIPTION
## What GitHub issue does this PR apply to?
 
Resolves #342 

## What changed and why?

Added the additional language features from the main meta file for control structures.

## Checklist
- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

Added in the use of System.Linq to achieve some of the functional elements such as map and reduce. Given it is part of the core assembly for .Net I think it serves its purpose in the context but it is a framework feature and not strictly a C# feature therefore wouldn't be available in Mono etc etc.

Only included the switch statement in this as other implementations in the language are focused around pattern matching which should probably be a concept in its own right.
