### PR TITLE
Error pages for missing language concepts showing viewers how to contribute

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -236,8 +236,12 @@ def reference(request):
     except Exception:
         error_message = ""
         if lang.lang_exists():
-            error_message = f"There is no entry about this structure/concept for the \
-                language ({lang.key}) yet.<br />"
+            error_message = f"There is no entry about this structure/concept ({structure_query_string}) for the \
+                language ({lang.key}) yet.<br /><br /> \
+                Would you like to add it? Check out our contribution guidelines <a href='https://docs.codethesaur.us/contributing/'>here</a>.<br />\
+                Then, when you're ready, you can start by adding a file named `{meta_structure.key}.json` at \
+                <a href='https://github.com/codethesaurus/codethesaur.us/new/main/web/thesauruses/{lang.key}'> \
+                https://github.com/codethesaurus/codethesaur.us/new/main/web/thesauruses/{lang.key}</a>"
         else:
             error_message = f"The language ({lang.key}) isn't valid. \
                 Double-check your URL and try again.<br />"

--- a/web/views.py
+++ b/web/views.py
@@ -139,8 +139,10 @@ def compare(request):
     except Exception:
         error_message = ""
         if lang2.lang_exists():
-            error_message = f"There is no entry about this structure/concept for the \
-                second language ({lang2.key}) yet.<br />"
+            f"There is no entry about this structure/concept ({meta_structure.key}) for the \
+               first language ({lang2.key} yet.<br /><br /> \
+               Would you like to add it? Check out our contribution guidelines <a href='https://docs.codethesaur.us/contributing/'>here</a>.<br />\
+               Then, when you're ready, you can start by adding a file named `{meta_structure.key}.json` at <a href='https://github.com/codethesaurus/codethesaur.us/new/main/web/thesauruses/{lang2.key}'>https://github.com/codethesaurus/codethesaur.us/new/main/web/thesauruses/{lang2.key}</a>"
         else:
             error_message = f"The second language ({lang2.key}) isn't valid. \
                 Double-check your URL and try again.<br />"

--- a/web/views.py
+++ b/web/views.py
@@ -119,8 +119,11 @@ def compare(request):
     except Exception:
         error_message = ""
         if lang1.lang_exists():
-            error_message = f"There is no entry about this structure/concept for the \
-                first language ({lang1.key}) yet.<br />"
+             error_message = f"There is no entry about this structure/concept ({meta_structure.key}) for the \
+                first language ({lang1.key}) yet.<br /><br /> \
+                Would you like to add it? Check out our contribution guidelines <a href='https://docs.codethesaur.us/contributing/'>here</a>.<br />\
+                Then, when you're ready, you can start by adding a file named `{meta_structure.key}.json` at <a href='https://github.com/codethesaurus/codethesaur.us/new/main/web/thesauruses/{lang1.key}'>https://github.com/codethesaurus/codethesaur.us/new/main/web/thesauruses/{lang1.key}</a>"
+
         else:
             error_message = f"The first language ({lang1.key}) isn't valid. \
                 Double-check your URL and try again.<br />"


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

<!-- Replace "xxxx" below with the issue number.  -->
<!-- You can change it to say only "Closes #", "Fixes #", or "Resolves #". -->
<!-- Don't add the word "issue" to it otherwise it won't link. -->

Resolves #243 


## What changed and why?

I added some links to how to contribute to this project and to where you would add a file for the missing concept in the relevant language.


## (If editing Django app) Please add screenshots

![image](https://user-images.githubusercontent.com/954453/137535593-0d242af9-5dda-4437-876c-fdf17a5f4879.png)

The file name and the language concept are both variables matching whatever the user was looking for.

## Checklist

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [x] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

I commented on the issue to claim it, but I wasn't assigned it yet - no hurry to review!
