### PR TITLE
Python: add control switch

### DIFF
--- a/web/thesauruses/bash/control_structures.json
+++ b/web/thesauruses/bash/control_structures.json
@@ -42,7 +42,7 @@
       "code": "if condition; then statements; elif condition; then statements; else statements; fi"
     },
     "switch_statement": {
-      "code": "case expresssion in\n  pattern1 )\n    statements ;;\n  pattern2 )\n    statements;;\nesac"
+      "code": "case expression in\n  pattern1 )\n    statements ;;\n  pattern2 )\n    statements;;\nesac"
     },
     "ternary_conditional": {
       "not_implemented": true

--- a/web/thesauruses/meta_info.json
+++ b/web/thesauruses/meta_info.json
@@ -11,7 +11,7 @@
     "Nim (version 1.4)": "nim",
     "Objective-C (version 2.0)": "objectivec",
     "PHP (version 7.4)": "php",
-    "Python (version 3.7)": "python",
+    "Python (version 3.10)": "python",
     "Ruby (version 3.0)": "ruby",
     "Rust (version 1)": "rust",
     "Scala (version 2.13)": "scala",

--- a/web/thesauruses/python/control_structures.json
+++ b/web/thesauruses/python/control_structures.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "language": "python",
-    "language_version": "3.7",
+    "language_version": "3.10",
     "language_name": "Python"
   },
   "categories": {
@@ -10,6 +10,7 @@
       "if_else_conditional",
       "if_elseif_conditional",
       "if_elseif_else_conditional",
+      "switch_statement",
       "ternary_conditional"
     ],
     "Loops": [
@@ -35,6 +36,10 @@
     },
     "if_elseif_else_conditional": {
       "code": "if condition:\n    statements\nelif condition:\n    statements\nelse:\n    statements"
+    },
+    "switch_statement": {
+      "comment": "This control structure was introduced with Python 3.10 and is more powerful than shown here.",
+      "code": "match condition:\n    case value1:\n        statements\n    case value2:\n        statements"
     },
     "ternary_conditional": {
       "code": "expression_if_true if condition else expression_if_false"

--- a/web/thesauruses/python/data_types.json
+++ b/web/thesauruses/python/data_types.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "language": "python",
-    "language_version": "3.7",
+    "language_version": "3.10",
     "language_name": "Python"
   },
   "categories": {

--- a/web/thesauruses/python/functions.json
+++ b/web/thesauruses/python/functions.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "language": "python",
-    "language_version": "3.7",
+    "language_version": "3.10",
     "language_name": "Python"
   },
   "categories": {


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

None

## What changed and why?

* Python 3.10 introduces a switch-equivalent statement, so filled in the data to describe this
* Bumped the version of Python 3.7 to 3.10 throughout, for consistency
* Fixed a typo in the bash switch-equivalent, spotted whilst using it as a cross-reference


## Checklist

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes

## Any additional comments or things to be aware of while reviewing?

Python 3.10's `match` is closer to a type-based language's model.
