### PR TITLE
Support array code blocks

### DIFF
--- a/web/Language.py
+++ b/web/Language.py
@@ -89,7 +89,10 @@ class Language:
         :param concept_key: ID for the concept
         :return: the string containing the concept's code
         """
-        return self.concept(concept_key).get("code")
+        code =  self.concept(concept_key).get("code")
+        if isinstance(code, list):
+            code = "\n".join(code)
+        return code
 
     def concept_comment(self, concept_key):
         """

--- a/web/tests/test_meta_structures.py
+++ b/web/tests/test_meta_structures.py
@@ -72,7 +72,7 @@ class TestMetaStructures(TestCase):
 		language_friendly_name = "Alphabet language!"
 
 		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
-		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"}}")
+		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
@@ -90,13 +90,14 @@ class TestMetaStructures(TestCase):
 		self.assertEquals(language.concept("concept1"), dict({"code": "abc"}))
 		self.assertEquals(language.concept("concept2"), dict({"code": "abc", "comment": "My comment"}))
 		self.assertEquals(language.concept("concept3"), dict({"code": "", "comment": "", "not-implemented": True}))
+		self.assertEquals(language.concept("concept4"), dict({"code": ["line1","line2"]}))
 
 	def test_language_concept_unknown(self):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
 		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
-		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"}}")
+		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
@@ -111,13 +112,14 @@ class TestMetaStructures(TestCase):
 		self.assertEquals(language.concept_unknown("concept1"), False)
 		self.assertEquals(language.concept_unknown("concept2"), False)
 		self.assertEquals(language.concept_unknown("concept3"), False)
+		self.assertEquals(language.concept_unknown("concept4"), False)
 
 	def test_language_concept_implemented(self):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
 		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
-		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"}}")
+		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
@@ -133,13 +135,14 @@ class TestMetaStructures(TestCase):
 		self.assertEquals(language.concept_implemented("concept1"), True)
 		self.assertEquals(language.concept_implemented("concept2"), True)
 		self.assertEquals(language.concept_implemented("concept3"), False)
+		self.assertEquals(language.concept_implemented("concept4"), True)
 
 	def test_language_get_concept_code(self):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
 		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
-		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"}}")
+		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
@@ -155,13 +158,14 @@ class TestMetaStructures(TestCase):
 		self.assertEquals(language.concept_code("concept1"), "abc")
 		self.assertEquals(language.concept_code("concept2"), "abc")
 		self.assertEquals(language.concept_code("concept3"), "")
+		self.assertEquals(language.concept_code("concept4"), "line1\nline2")
 
 	def test_language_get_concept_comment(self):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
 		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
-		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"}}")
+		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
@@ -177,4 +181,5 @@ class TestMetaStructures(TestCase):
 		self.assertEquals(language.concept_comment("concept1"), "")
 		self.assertEquals(language.concept_comment("concept2"), "My comment")
 		self.assertEquals(language.concept_comment("concept3"), "")
+		self.assertEquals(language.concept_comment("concept4"), "")
 

--- a/web/thesauruses/_meta/classes.json
+++ b/web/thesauruses/_meta/classes.json
@@ -43,99 +43,99 @@
   "classes": {
     "normal_class": {
       "name": "Normal class",
-      "code": ""
+      "code": [""]
     },
     "abstract_class": {
       "name": "Abstract class",
-      "code": ""
+      "code": [""]
     },
     "interface": {
       "name": "Interface",
-      "code": ""
+      "code": [""]
     },
     "read_only_class": {
       "name": "Read-only class",
-      "code": ""
+      "code": [""]
     },
     "static_class": {
       "name": "Static class",
-      "code": ""
+      "code": [""]
     },
     "inner_class": {
       "name": "Inner class",
-      "code": ""
+      "code": [""]
     },
     "packages": {
       "name": "Packages",
-      "code": ""
+      "code": [""]
     },
     "class_with_generic_type": {
       "name": "Class with a generic type",
-      "code": ""
+      "code": [""]
     },
     "private_variables": {
       "name": "Defining private variables",
-      "code": ""
+      "code": [""]
     },
     "protected_variables": {
       "name": "Defining protected variables",
-      "code": ""
+      "code": [""]
     },
     "public_variables": {
       "name": "Defining public variables",
-      "code": ""
+      "code": [""]
     },
     "static_variables": {
       "name": "Defining static variables",
-      "code": ""
+      "code": [""]
     },
     "private_functions": {
       "name": "Defining private functions",
-      "code": ""
+      "code": [""]
     },
     "protected_functions": {
       "name": "Defining protected functions",
-      "code": ""
+      "code": [""]
     },
     "public_functions": {
       "name": "Defining public functions",
-      "code": ""
+      "code": [""]
     },
     "static_functions": {
       "name": "Defining static functions",
-      "code": ""
+      "code": [""]
     },
     "extends_class": {
       "name": "Class that inherits/extends another class",
-      "code": ""
+      "code": [""]
     },
     "extending_interface": {
       "name": "Class/Interface that inherits/extends another class/interface",
-      "code": ""
+      "code": [""]
     },
     "calling_superclass_functions": {
       "name": "Calling a superclass function",
-      "code": ""
+      "code": [""]
     },
     "overriding_superclass_functions": {
       "name": "Overriding a superclass function",
-      "code": ""
+      "code": [""]
     },
     "instantiating_object": {
       "name": "Instantiating a new object",
-      "code": ""
+      "code": [""]
     },
     "instantiating_polymorphic_object": {
       "name": "Instantiating a polymorphic object",
-      "code": ""
+      "code": [""]
     },
     "implement_constructor": {
       "name": "Implementing a class constructor",
-      "code": ""
+      "code": [""]
     },
     "implement_deconstructor": {
       "name": "Implementing a class deconstructor",
-      "code": ""
+      "code": [""]
     }
   }
 }

--- a/web/thesauruses/_meta/control_structures.json
+++ b/web/thesauruses/_meta/control_structures.json
@@ -32,70 +32,70 @@
   "control_structures": {
     "if_conditional": {
       "name": "If conditional",
-      "code": ""
+      "code": [""]
     },
     "if_else_conditional": {
       "name": "If/Else conditional",
-      "code": ""
+      "code": [""]
     },
     "if_elseif_conditional": {
       "name": "If/ElseIf conditional",
-      "code": ""
+      "code": [""]
     },
     "if_elseif_else_conditional": {
       "name": "If/ElseIf/Else conditional",
-      "code": ""
+      "code": [""]
     },
     "switch_statement": {
       "name": "Switch statement"
     },
     "ternary_conditional": {
       "name": "Ternary conditional",
-      "code": ""
+      "code": [""]
     },
     "while_loop": {
       "name": "While loop",
-      "code": ""
+      "code": [""]
     },
     "do_while_loop": {
       "name": "Do/While loop",
-      "code": ""
+      "code": [""]
     },
     "until_loop": {
       "name": "Until loop",
-      "code": ""
+      "code": [""]
     },
     "do_until_loop": {
       "name": "Do/Until loop",
-      "code": ""
+      "code": [""]
     },
     "for_loop": {
       "name": "For loop",
-      "code": ""
+      "code": [""]
     },
     "foreach_loop": {
       "name": "Foreach loop",
-      "code": ""
+      "code": [""]
     },
     "list_comprehension": {
       "name": "List Comprehension",
-      "code": ""
+      "code": [""]
     },
     "each_iteration": {
       "name": "Each iteration",
-      "code": ""
+      "code": [""]
     },
     "map_iteration": {
       "name": "Map iteration",
-      "code": ""
+      "code": [""]
     },
     "filter_iteration": {
       "name": "Filter iteration",
-      "code": ""
+      "code": [""]
     },
     "fold_iteration": {
       "name": "Fold iteration",
-      "code": ""
+      "code": [""]
     }
   }
 }

--- a/web/thesauruses/_meta/data_types.json
+++ b/web/thesauruses/_meta/data_types.json
@@ -40,103 +40,103 @@
   "data_types": {
     "boolean": {
       "name": "Boolean",
-      "code": ""
+      "code": [""]
     },
     "signed_integer_8_bit": {
       "name": "Signed 8-bit integer",
-      "code": ""
+      "code": [""]
     },
     "unsigned_integer_8_bit": {
       "name": "Unsigned 8-bit integer",
-      "code": ""
+      "code": [""]
     },
     "signed_integer_16_bit": {
       "name": "Signed 16-bit integer",
-      "code": ""
+      "code": [""]
     },
     "unsigned_integer_16_bit": {
       "name": "Unsigned 16-bit integer",
-      "code": ""
+      "code": [""]
     },
     "signed_integer_32_bit": {
       "name": "Signed 32-bit integer",
-      "code": ""
+      "code": [""]
     },
     "unsigned_integer_32_bit": {
       "name": "Unsigned 32-bit integer",
-      "code": ""
+      "code": [""]
     },
     "signed_integer_64_bit": {
       "name": "Signed 64-bit integer",
-      "code": ""
+      "code": [""]
     },
     "unsigned_integer_64_bit": {
       "name": "Unsigned 64-bit integer",
-      "code": ""
+      "code": [""]
     },
     "signed_integer_as_object": {
       "name": "Signed object-based Integer",
-      "code": ""
+      "code": [""]
     },
     "unsigned_integer_as_object": {
       "name": "Unsigned object-based Integer",
-      "code": ""
+      "code": [""]
     },
     "signed_float_16_bit": {
       "name": "Signed 16-bit floating point",
-      "code": ""
+      "code": [""]
     },
     "unsigned_float_16_bit": {
       "name": "Unsigned 16-bit floating point",
-      "code": ""
+      "code": [""]
     },
     "signed_float_32_bit": {
       "name": "Signed 32-bit floating point",
-      "code": ""
+      "code": [""]
     },
     "unsigned_float_32_bit": {
       "name": "Unsigned 32-bit floating point",
-      "code": ""
+      "code": [""]
     },
     "signed_float_64_bit": {
       "name": "Signed 64-bit floating point",
-      "code": ""
+      "code": [""]
     },
     "unsigned_float_64_bit": {
       "name": "Unsigned 64-bit floating point",
-      "code": ""
+      "code": [""]
     },
     "signed_float_as_object": {
       "name": "Signed object-based floating point",
-      "code": ""
+      "code": [""]
     },
     "unsigned_float_as_object": {
       "name": "Unsigned object-based floating point",
-      "code": ""
+      "code": [""]
     },
     "character": {
       "name": "Character",
-      "code": ""
+      "code": [""]
     },
     "string_as_object": {
       "name": "String as an object",
-      "code": ""
+      "code": [""]
     },
     "string_as_array": {
       "name": "String as an array of characters",
-      "code": ""
+      "code": [""]
     },
     "complex_as_object": {
       "name": "Complex Number as an object",
-      "code": ""
+      "code": [""]
     },
     "real_number_part": {
       "name": "Complex number real part",
-      "code": ""
+      "code": [""]
     },
     "imaginary_number_part": {
       "name": "Complex number imaginary part",
-      "code": ""
+      "code": [""]
     }
   }
 }

--- a/web/thesauruses/_meta/functions.json
+++ b/web/thesauruses/_meta/functions.json
@@ -31,59 +31,59 @@
   "functions": {
     "void_function_no_parameters": {
       "name": "Function that does not return a value and takes no parameters",
-      "code": ""
+      "code": [""]
     },
     "void_function_with_parameters": {
       "name": "Function that does not return a value and that takes 1 or more defined parameters",
-      "code": ""
+      "code": [""]
     },
     "void_function_with_keyword_parameters": {
       "name": "Function that does not return a value and that takes 0 or more defined keyword parameters",
-      "code": ""
+      "code": [""]
     },
     "void_function_variable_parameters": {
       "name": "Function that does not return a value and function that takes an unknown number of parameters",
-      "code": ""
+      "code": [""]
     },
     "return_value_function_no_parameters": {
       "name": "Function that returns a value and takes no parameters",
-      "code": ""
+      "code": [""]
     },
     "return_value_function_with_parameters": {
       "name": "Function that returns a value and takes 1 or more defined parameters",
-      "code": ""
+      "code": [""]
     },
     "return_value_function_with_keyword_parameters": {
       "name": "Function that returns a value and takes 0 or more defined keyword parameters",
-      "code": ""
+      "code": [""]
     },
     "return_value_function_variable_parameters": {
       "name": "Function that returns a value and takes an unknown number of parameters",
-      "code": ""
+      "code": [""]
     },
     "anonymous_function_no_parameters": {
       "name": "Anonymous function that takes no parameters",
-      "code": ""
+      "code": [""]
     },
     "anonymous_function_with_parameters": {
       "name": "Anonymous function that takes 1 or more defined parameters",
-      "code": ""
+      "code": [""]
     },
     "anonymous_function_with_keyword_parameters": {
       "name": "Anonymous function that takes 0 or more defined keyword parameters",
-      "code": ""
+      "code": [""]
     },
     "anonymous_function_variable_parameters": {
       "name": "Anonymous function that takes an unknown number of parameters",
-      "code": ""
+      "code": [""]
     },
     "call_subroutine": {
       "name": "Call subroutine",
-      "code": ""
+      "code": [""]
     },
     "return_from_subroutine": {
       "name": "Return from subroutine",
-      "code": ""
+      "code": [""]
     }
   }
 }

--- a/web/thesauruses/_meta/lists.json
+++ b/web/thesauruses/_meta/lists.json
@@ -123,343 +123,343 @@
   "lists": {
     "name_of_ordered_mutable_list": {
       "name": "What is a ordered, mutable list called?",
-      "code": ""
+      "code": [""]
     },
     "create_a_ordered_mutable_list": {
       "name": "Create the list",
-      "code": ""
+      "code": [""]
     },
     "ordered_mutable_list_start_number": {
       "name": "What number does it start at?",
-      "code": ""
+      "code": [""]
     },
     "ordered_mutable_list_can_be_appended": {
       "name": "Can you append to it?",
-      "code": ""
+      "code": [""]
     },
     "ordered_mutable_list_can_be_inserted_in_middle": {
       "name": "Can you insert into the middle of it?",
-      "code": ""
+      "code": [""]
     },
     "access_element_in_ordered_mutable_list": {
       "name": "Access element by index",
-      "code": ""
+      "code": [""]
     },
     "insert_into_beginning_of_ordered_mutable_list": {
       "name": "Insert element at beginning",
-      "code": ""
+      "code": [""]
     },
     "insert_into_end_of_ordered_mutable_list": {
       "name": "Insert element at end",
-      "code": ""
+      "code": [""]
     },
     "insert_into_middle_of_ordered_mutable_list": {
       "name": "Insert element in middle",
-      "code": ""
+      "code": [""]
     },
     "erase_element_at_beginning_of_ordered_mutable_list": {
       "name": "Erase first element",
-      "code": ""
+      "code": [""]
     },
     "erase_element_at_end_of_ordered_mutable_list": {
       "name": "Erase last element",
-      "code": ""
+      "code": [""]
     },
     "erase_element_in_middle_of_ordered_mutable_list": {
       "name": "Erase element in the middle",
-      "code": ""
+      "code": [""]
     },
     "swap_elements_in_ordered_mutable_list": {
       "name": "Swap two elements",
-      "code": ""
+      "code": [""]
     },
     "delete_ordered_mutable_list": {
       "name": "Delete the list",
-      "code": ""
+      "code": [""]
     },
     "name_of_unordered_mutable_list": {
       "name": "What is a unordered, mutable list called?",
-      "code": ""
+      "code": [""]
     },
     "create_a_unordered_mutable_list": {
       "name": "unordered",
-      "code": ""
+      "code": [""]
     },
     "unordered_mutable_list_start_number": {
       "name": "What number does it start at?",
-      "code": ""
+      "code": [""]
     },
     "unordered_mutable_list_can_be_appended": {
       "name": "Can you append to it?",
-      "code": ""
+      "code": [""]
     },
     "unordered_mutable_list_can_be_inserted_in_middle": {
       "name": "Can you insert into the middle of it?",
-      "code": ""
+      "code": [""]
     },
     "access_element_in_unordered_mutable_list": {
       "name": "Access element by index",
-      "code": ""
+      "code": [""]
     },
     "insert_into_beginning_of_unordered_mutable_list": {
       "name": "Insert element at beginning",
-      "code": ""
+      "code": [""]
     },
     "insert_into_end_of_unordered_mutable_list": {
       "name": "Insert element at end",
-      "code": ""
+      "code": [""]
     },
     "insert_into_middle_of_unordered_mutable_list": {
       "name": "Insert element in middle",
-      "code": ""
+      "code": [""]
     },
     "erase_element_at_beginning_of_unordered_mutable_list": {
       "name": "Erase first element",
-      "code": ""
+      "code": [""]
     },
     "erase_element_at_end_of_unordered_mutable_list": {
       "name": "Erase last element",
-      "code": ""
+      "code": [""]
     },
     "erase_element_in_middle_of_unordered_mutable_list": {
       "name": "Erase element in the middle",
-      "code": ""
+      "code": [""]
     },
     "swap_elements_in_unordered_mutable_list": {
       "name": "Swap two elements",
-      "code": ""
+      "code": [""]
     },
     "delete_unordered_mutable_list": {
       "name": "Delete the list",
-      "code": ""
+      "code": [""]
     },
     "name_of_ordered_immutable_list": {
       "name": "What is a ordered, immutable list called?",
-      "code": ""
+      "code": [""]
     },
     "create_a_ordered_immutable_list": {
       "name": "Create the list",
-      "code": ""
+      "code": [""]
     },
     "ordered_immutable_list_start_number": {
       "name": "What number does it start at?",
-      "code": ""
+      "code": [""]
     },
     "access_element_in_ordered_immutable_list": {
       "name": "Access element by index",
-      "code": ""
+      "code": [""]
     },
     "delete_ordered_immutable_list": {
       "name": "Delete the list",
-      "code": ""
+      "code": [""]
     },
     "name_of_unordered_immutable_list": {
       "name": "What is a unordered, immutable list called?",
-      "code": ""
+      "code": [""]
     },
     "create_a_unordered_immutable_list": {
       "name": "Create the list",
-      "code": ""
+      "code": [""]
     },
     "unordered_immutable_list_start_number": {
       "name": "What number does it start at?",
-      "code": ""
+      "code": [""]
     },
     "access_element_in_unordered_immutable_list": {
       "name": "Access element by index",
-      "code": ""
+      "code": [""]
     },
     "delete_unordered_immutable_list": {
       "name": "Delete the list",
-      "code": ""
+      "code": [""]
     },
     "name_of_mutable_hashed_list": {
       "name": "What is a mutable hashed list called?",
-      "code": ""
+      "code": [""]
     },
     "create_a_mutable_hashed_list": {
       "name": "Create the list",
-      "code": ""
+      "code": [""]
     },
     "insert_element_to_mutable_hashed_list": {
       "name": "Insert an element",
-      "code": ""
+      "code": [""]
     },
     "erase_element_from_mutable_hashed_list": {
       "name": "Erase an element from the list",
-      "code": ""
+      "code": [""]
     },
     "delete_mutable_hashed_list": {
       "name": "Delete the list",
-      "code": ""
+      "code": [""]
     },
     "name_of_immutable_hashed_list": {
       "name": "What is an immutable hashed list called?",
-      "code": ""
+      "code": [""]
     },
     "create_a_immutable_hashed_list": {
       "name": "Create the list",
-      "code": ""
+      "code": [""]
     },
     "insert_element_to_immutable_hashed_list": {
       "name": "Insert an element",
-      "code": ""
+      "code": [""]
     },
     "erase_element_from_immutable_hashed_list": {
       "name": "Erase an element from the list",
-      "code": ""
+      "code": [""]
     },
     "delete_immutable_hashed_list": {
       "name": "Delete the list",
-      "code": ""
+      "code": [""]
     },
     "create_a_mutable_set": {
       "name": "Create a mutable key/value set",
-      "code": ""
+      "code": [""]
     },
     "get_key_from_mutable_set": {
       "name": "Get key",
-      "code": ""
+      "code": [""]
     },
     "get_value_from_mutable_set": {
       "name": "Get value",
-      "code": ""
+      "code": [""]
     },
     "get_all_keys_from_mutable_set": {
       "name": "Get all keys",
-      "code": ""
+      "code": [""]
     },
     "get_all_values_from_mutable_set": {
       "name": "Get all values",
-      "code": ""
+      "code": [""]
     },
     "swap_key_and_value_in_mutable_set": {
       "name": "Swap a key and value",
-      "code": ""
+      "code": [""]
     },
     "delete_mutable_set": {
       "name": "Delete the set",
-      "code": ""
+      "code": [""]
     },
     "create_a_immutable_set": {
       "name": "Create an immutable key/value set",
-      "code": ""
+      "code": [""]
     },
     "get_key_from_immutable_set": {
       "name": "Get key",
-      "code": ""
+      "code": [""]
     },
     "get_value_from_immutable_set": {
       "name": "Get value",
-      "code": ""
+      "code": [""]
     },
     "get_all_keys_from_immutable_set": {
       "name": "Get all keys",
-      "code": ""
+      "code": [""]
     },
     "get_all_values_from_immutable_set": {
       "name": "Get all values",
-      "code": ""
+      "code": [""]
     },
     "swap_key_and_value_in_immutable_set": {
       "name": "Swap a key and value",
-      "code": ""
+      "code": [""]
     },
     "delete_immutable_set": {
       "name": "Delete the set",
-      "code": ""
+      "code": [""]
     },
     "find_element_at_position": {
       "name": "Find/search for an element at an index position",
-      "code": ""
+      "code": [""]
     },
     "find_element_by_value": {
       "name": "Find/search for an element by value",
-      "code": ""
+      "code": [""]
     },
     "find_minimum_element": {
       "name": "Find the minimum value in a list",
-      "code": ""
+      "code": [""]
     },
     "find_maximum_element": {
       "name": "Find the maximum value in a list",
-      "code": ""
+      "code": [""]
     },
     "convert_list_to_string": {
       "name": "Convert a list to a string",
-      "code": ""
+      "code": [""]
     },
     "concatenate_two_lists": {
       "name": "Concatenate two lists together",
-      "code": ""
+      "code": [""]
     },
     "split_list_at_index": {
       "name": "Split lists at an index",
-      "code": ""
+      "code": [""]
     },
     "split_list_at_value": {
       "name": "Split list at a value",
-      "code": ""
+      "code": [""]
     },
     "duplicate_a_list": {
       "name": "Duplicate a list",
-      "code": ""
+      "code": [""]
     },
     "duplicate_subset_of_list": {
       "name": "Duplicate a portion/subset of a list",
-      "code": ""
+      "code": [""]
     },
     "get_list_length": {
       "name": "Get list length",
-      "code": ""
+      "code": [""]
     },
     "resize_list": {
       "name": "Increase/decrease list size",
-      "code": ""
+      "code": [""]
     },
     "do_two_lists_match_exactly": {
       "name": "Do two lists match every element?",
-      "code": ""
+      "code": [""]
     },
     "do_two_lists_contain_same_items": {
       "name": "Do two lists contain all the same items?",
-      "code": ""
+      "code": [""]
     },
     "does_list_satisfy_some_expression": {
       "name": "Does a list satisfy some expression?",
-      "code": ""
+      "code": [""]
     },
     "does_list_not_satisfy_an_expression": {
       "name": "Does a list entirely not satisfy an expression?",
-      "code": ""
+      "code": [""]
     },
     "sort_list": {
       "name": "Sort a list",
-      "code": ""
+      "code": [""]
     },
     "shuffle_list": {
       "name": "Shuffle list elements",
-      "code": ""
+      "code": [""]
     },
     "reverse_list": {
       "name": "Reverse order of list elements",
-      "code": ""
+      "code": [""]
     },
     "map": {
       "name": "Map function across list",
-      "code": ""
+      "code": [""]
     },
     "filter": {
       "name": "Filter a list based on criteria",
-      "code": ""
+      "code": [""]
     },
     "reduce_left": {
       "name": "Reduce a list left-to-right",
-      "code": ""
+      "code": [""]
     },
     "reduce_right": {
       "name": "Reduce a list right-to-left",
-      "code": ""
+      "code": [""]
     }
   }
 }

--- a/web/thesauruses/_meta/operators.json
+++ b/web/thesauruses/_meta/operators.json
@@ -59,183 +59,183 @@
   "operators": {
     "addition": {
       "name": "Addition operator",
-      "code": ""
+      "code": [""]
     },
     "addition_assignment": {
       "name": "Addition and assignment operator",
-      "code": ""
+      "code": [""]
     },
     "subtraction": {
       "name": "Subtraction operator",
-      "code": ""
+      "code": [""]
     },
     "subtraction_assignment": {
       "name": "Subtraction and assignment operator",
-      "code": ""
+      "code": [""]
     },
     "multiplication": {
       "name": "Multiplication operator",
-      "code": ""
+      "code": [""]
     },
     "multiplication_assignment": {
       "name": "Multiplication and assignment operator",
-      "code": ""
+      "code": [""]
     },
     "division": {
       "name": "Division operator",
-      "code": ""
+      "code": [""]
     },
     "division_assignment": {
       "name": "Division and assignment operator",
-      "code": ""
+      "code": [""]
     },
     "integer_division": {
       "name": "Integer division operator",
-      "code": ""
+      "code": [""]
     },
     "integer_division_assignment": {
       "name": "Integer division and assignment operator",
-      "code": ""
+      "code": [""]
     },
     "modulus": {
       "name": "Modulus (remainder) operator",
-      "code": ""
+      "code": [""]
     },
     "modulus_assignment": {
       "name": "Modulus and assignment operator",
-      "code": ""
+      "code": [""]
     },
     "unary_plus": {
       "name": "Unary plus operator",
-      "code": ""
+      "code": [""]
     },
     "unary_minus": {
       "name": "Unary minus operator",
-      "code": ""
+      "code": [""]
     },
     "increment": {
       "name": "Increment (add 1) operator",
-      "code": ""
+      "code": [""]
     },
     "decrement": {
       "name": "Decrement (subtract 1) operator",
-      "code": ""
+      "code": [""]
     },
     "exponential": {
       "name": "Exponential operator",
-      "code": ""
+      "code": [""]
     },
     "factorial": {
       "name": "Factorial operator",
-      "code": ""
+      "code": [""]
     },
     "absolute_value": {
       "name": "Absolute value operator",
-      "code": ""
+      "code": [""]
     },
     "percentage": {
       "name": "Percentage operator",
-      "code": ""
+      "code": [""]
     },
     "equal_to": {
       "name": "Equality operator",
-      "code": ""
+      "code": [""]
     },
     "not_equal_to": {
       "name": "Not equal to operator",
-      "code": ""
+      "code": [""]
     },
     "less_than": {
       "name": "Less than operator",
-      "code": ""
+      "code": [""]
     },
     "less_than_or_equal_to": {
       "name": "Less than or equal to operator",
-      "code": ""
+      "code": [""]
     },
     "greater_than": {
       "name": "Greater than operator",
-      "code": ""
+      "code": [""]
     },
     "greater_than_or_equal_to": {
       "name": "Greater than or equal to operator",
-      "code": ""
+      "code": [""]
     },
     "null_coalescing": {
       "name": "Null coalescing operator",
-      "code": ""
+      "code": [""]
     },
     "is": {
       "name": "Is operator",
-      "code": ""
+      "code": [""]
     },
     "is_not": {
       "name": "Is not operator",
-      "code": ""
+      "code": [""]
     },
     "and": {
       "name": "Logical AND operator",
-      "code": ""
+      "code": [""]
     },
     "and_assignment": {
       "name": "Logical AND assignment operator",
-      "code": ""
+      "code": [""]
     },
     "or": {
       "name": "Logical OR operator",
-      "code": ""
+      "code": [""]
     },
     "or_assignment": {
       "name": "Logical OR assignment operator",
-      "code": ""
+      "code": [""]
     },
     "not": {
       "name": "Logical NOT operator",
-      "code": ""
+      "code": [""]
     },
     "not_assignment": {
       "name": "Logical NOT assignment operator",
-      "code": ""
+      "code": [""]
     },
     "xor": {
       "name": "Logical XOR operator",
-      "code": ""
+      "code": [""]
     },
     "xor_assignment": {
       "name": "Logical XOR assignment operator",
-      "code": ""
+      "code": [""]
     },
     "xnor": {
       "name": "Logical XNOR operator",
-      "code": ""
+      "code": [""]
     },
     "xnor_assignment": {
       "name": "Logical XNOR assignment operator",
-      "code": ""
+      "code": [""]
     },
     "left_shift": {
       "name": "Left shift bitwise operator",
-      "code": ""
+      "code": [""]
     },
     "left_shift_assignment": {
       "name": "Left shift assignment operator",
-      "code": ""
+      "code": [""]
     },
     "right_shift": {
       "name": "Right shift bitwise operator",
-      "code": ""
+      "code": [""]
     },
     "right_shift_assignment": {
       "name": "Right shift assignment operator",
-      "code": ""
+      "code": [""]
     },
     "ternary": {
       "name": "Ternary operator",
-      "code": ""
+      "code": [""]
     },
     "null_forgiving": {
       "name": "Null forgiving operator",
-      "code": ""
+      "code": [""]
     }
   }
 }

--- a/web/thesauruses/_meta/strings.json
+++ b/web/thesauruses/_meta/strings.json
@@ -82,255 +82,255 @@
   "strings": {
     "is_primitive_or_not": {
       "name": "Is this a built-in type in this language?",
-      "code": ""
+      "code": [""]
     },
     "import": {
       "name": "Import the string class",
-      "code": ""
+      "code": [""]
     },
     "default_string_byte_encoding": {
       "name": "Default byte encoding (ex: ASCII, UTF-8, UTF-16, etc.)",
-      "code": ""
+      "code": [""]
     },
     "create_new_string": {
       "name": "Create new string",
-      "code": ""
+      "code": [""]
     },
     "create_multiline_string": {
       "name": "Create new multi-line string",
-      "code": ""
+      "code": [""]
     },
     "assign_new_string": {
       "name": "Assign string from another string",
-      "code": ""
+      "code": [""]
     },
     "destroy_string": {
       "name": "Destroy string",
-      "code": ""
+      "code": [""]
     },
     "length_of_string": {
       "name": "Length of string",
-      "code": ""
+      "code": [""]
     },
     "max_length_of_string": {
       "name": "Maximum length of string",
-      "code": ""
+      "code": [""]
     },
     "clear_string": {
       "name": "Clear/empty string",
-      "code": ""
+      "code": [""]
     },
     "is_empty": {
       "name": "Is string empty?",
-      "code": ""
+      "code": [""]
     },
     "concatenate_two_strings": {
       "name": "Concatenate/join two strings",
-      "code": ""
+      "code": [""]
     },
     "concatenate_many_strings": {
       "name": "Concatenate/join many strings",
-      "code": ""
+      "code": [""]
     },
     "is_all_alphabetical": {
       "name": "Is string all alphabetical characters?",
-      "code": ""
+      "code": [""]
     },
     "is_all_numerical": {
       "name": "Is string all numerical characters?",
-      "code": ""
+      "code": [""]
     },
     "is_all_alphanumeric": {
       "name": "Is string all alphanumeric characters?",
-      "code": ""
+      "code": [""]
     },
     "is_decimal": {
       "name": "Is string a decimal number?",
-      "code": ""
+      "code": [""]
     },
     "is_all_whitespaces": {
       "name": "Is string all whitespace characters?",
-      "code": ""
+      "code": [""]
     },
     "is_all_uppercase": {
       "name": "Is string all uppercase characters?",
-      "code": ""
+      "code": [""]
     },
     "is_all_lowercase": {
       "name": "Is string all lowercase characters?",
-      "code": ""
+      "code": [""]
     },
     "is_in_titlecase": {
       "name": "Is string formatted in title case?",
-      "code": ""
+      "code": [""]
     },
     "does_substring_exist": {
       "name": "Does a substring exist in a string?",
-      "code": ""
+      "code": [""]
     },
     "find_start_index_of_substring": {
       "name": "Find index of where a substring starts",
-      "code": ""
+      "code": [""]
     },
     "find_start_index_of_additional_substring": {
       "name": "Find index of an additional substring (or starting at another index)",
-      "code": ""
+      "code": [""]
     },
     "find_start_index_of_substring_from_end": {
       "name": "Find substring index starting at end",
-      "code": ""
+      "code": [""]
     },
     "count_occurrences_of_substring": {
       "name": "Find number of occurences of a substring",
-      "code": ""
+      "code": [""]
     },
     "get_leftmost_characters": {
       "name": "Get a specified number of characters from the left",
-      "code": ""
+      "code": [""]
     },
     "get_rightmost_characters": {
       "name": "Get a specified number of characters from the right",
-      "code": ""
+      "code": [""]
     },
     "get_substring_from_start_and_end_index": {
       "name": "Return a substring from a string based on starting and ending indices",
-      "code": ""
+      "code": [""]
     },
     "get_substring_from_start_index_and_length": {
       "name": "Return a substring from a string based on starting index and size of substring",
-      "code": ""
+      "code": [""]
     },
     "convert_to_uppercase": {
       "name": "Convert string to all uppercase",
-      "code": ""
+      "code": [""]
     },
     "convert_to_lowercase": {
       "name": "Convert string to all lowercase",
-      "code": ""
+      "code": [""]
     },
     "convert_to_title_case": {
       "name": "Convert string to title case",
-      "code": ""
+      "code": [""]
     },
     "capitalize_string": {
       "name": "Capitalize first letter of a string",
-      "code": ""
+      "code": [""]
     },
     "remove_whitespace": {
       "name": "Remove all whitespaces from string",
-      "code": ""
+      "code": [""]
     },
     "replace_substring": {
       "name": "Replace a substring with another string",
-      "code": ""
+      "code": [""]
     },
     "replace_all_substring": {
       "name": "Replace all substring matches with another string",
-      "code": ""
+      "code": [""]
     },
     "split_at_index": {
       "name": "Split string into a list of strings at a given index",
-      "code": ""
+      "code": [""]
     },
     "split_at_newlines": {
       "name": "Split string into a list of strings at every new line character",
-      "code": ""
+      "code": [""]
     },
     "split_at_substring": {
       "name": "Split string by locating all substrings",
-      "code": ""
+      "code": [""]
     },
     "merge_lists_into_string": {
       "name": "Merge a list of strings into one string",
-      "code": ""
+      "code": [""]
     },
     "encode_html_entities": {
       "name": "Encode HTML entities in a string (ex: ™ to &trade;)",
-      "code": ""
+      "code": [""]
     },
     "decode_html_entities": {
       "name": "Decode HTML entitles into characters",
-      "code": ""
+      "code": [""]
     },
     "encode_url_percent": {
       "name": "Encode URL percent encoding into string (ex: ' ' to %20)",
-      "code": ""
+      "code": [""]
     },
     "decode_url_percent": {
       "name": "Decode URL percent encoding",
-      "code": ""
+      "code": [""]
     },
     "encode_to_base64": {
       "name": "Encode string into Base64 format",
-      "code": ""
+      "code": [""]
     },
     "decode_from_base64": {
       "name": "Decode string from Base64 format",
-      "code": ""
+      "code": [""]
     },
     "format_string_function": {
       "name": "Function to format a string",
-      "code": ""
+      "code": [""]
     },
     "parameter_format_in_order": {
       "name": "Parameter used in format function if they're used in order",
-      "code": ""
+      "code": [""]
     },
     "parameter_format_numerical": {
       "name": "Parameter used in format function if they're numerically numbered",
-      "code": ""
+      "code": [""]
     },
     "parameter_format_by_name": {
       "name": "Paramater used in format function if they're named variables",
-      "code": ""
+      "code": [""]
     },
     "format_as_integer": {
       "name": "Format parameter as an integer",
-      "code": ""
+      "code": [""]
     },
     "format_as_decimal": {
       "name": "Format parameter as a decimal number",
-      "code": ""
+      "code": [""]
     },
     "format_as_fixed_decimal": {
       "name": "Format parameter as a fixed-point decimal number",
-      "code": ""
+      "code": [""]
     },
     "format_as_currency": {
       "name": "Format parameter as a currency number",
-      "code": ""
+      "code": [""]
     },
     "format_as_percentage": {
       "name": "Format parameter as a percentage number",
-      "code": ""
+      "code": [""]
     },
     "format_number_with_separators": {
       "name": "Format number with thousand separators",
-      "code": ""
+      "code": [""]
     },
     "format_number_with_positive_negative_sign": {
       "name": "Format number with positive/negative signs",
-      "code": ""
+      "code": [""]
     },
     "format_number_in_scientific_notation_little_e": {
       "name": "Format number with scientific notation with 'e'",
-      "code": ""
+      "code": [""]
     },
     "format_number_in_scientific_notation_big_e": {
       "name": "Format number with scientific notation with 'E'",
-      "code": ""
+      "code": [""]
     },
     "format_number_in_binary": {
       "name": "Format number into binary",
-      "code": ""
+      "code": [""]
     },
     "format_number_in_octal": {
       "name": "Format number into octal",
-      "code": ""
+      "code": [""]
     },
     "format_number_in_hexadecimal": {
       "name": "Format number into hexadecimal",
-      "code": ""
+      "code": [""]
     }
   }
 }


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->


## What GitHub issue does this PR apply to?

<!-- Replace "xxxx" below with the issue number.  -->
<!-- You can change it to say only "Closes #", "Fixes #", or "Resolves #". -->
<!-- Don't add the word "issue" to it otherwise it won't link. -->
Closes #372 


## What changed and why?

<!-- Please replace this line with a description of the changes -->
Allow parsing of JSON files with code blocks defined as array 

e,g, Instead of 
```json
{
  "code": "very long concept\nseveral lines are hard to read \nlets make it easy"
}
```
becomes
```json
{
  "code": [
    "very long concept", 
    "several lines are hard to read", 
    "lets make it easy"
  ]
}
```

Both options are still supported, though I updated the templates to an array containing a single string `[""]` to hint that arrays are supported. Perhaps the docs should also be updated to reflect this

## (If editing Django app) Please add screenshots

<!-- Please copy screenshots, then replace this line by pasting screenshots here -->
<!-- If this doesn't apply, you can delete this header and section. -->


## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [x] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

<!-- Please replace this line with any comments -->

