### PR TITLE
handle newlines in comments

### DIFF
--- a/web/templates/comparecard.html
+++ b/web/templates/comparecard.html
@@ -7,7 +7,7 @@
     {% endif %}
     {% if comment %}
         <div>
-            {{ comment|markdownify }}
+            {{ comment|markdownify|linebreaksbr }}
         </div>
     {% endif %}
     </div>

--- a/web/tests/test_templates.py
+++ b/web/tests/test_templates.py
@@ -51,7 +51,7 @@ class TestTemplates(TestCase):
             "</div>"
         )
 
-        # code and comment
+        # code and comment (single line)
         rendered_template_4 = render_to_string(
             "comparecard.html",
             {
@@ -69,6 +69,28 @@ class TestTemplates(TestCase):
             "    \n"
             "        <div>\n"
             "            I am <strong>bold</strong> and <em>italic</em>, <code>let x = 1</code>.\n"
+            "        </div>\n"
+            "    \n"
+            "    </div>\n"
+            "</div>"
+        )
+
+        # no code and comment (multiple lines)
+        rendered_template_4 = render_to_string(
+            "comparecard.html",
+            {
+                "code": "",
+                "comment": "I am a humble\nmulti-line comment in the\nform of a haiku"
+            }
+        ).strip()
+        self.assertEquals(
+            rendered_template_3,
+            "<div class=\"card\">\n"
+            "    <div class=\"card-body\">\n"
+            "    \n"
+            "    \n"
+            "        <div>\n"
+            "            I am a humble<br>multi-line comment in the<br>form of a haiku\n"
             "        </div>\n"
             "    \n"
             "    </div>\n"


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Fixes #362

## What changed and why?

`comparecard.html` now calls `linebreaksbr` to convert `comment` newlines into `<br>` 

Before: `{{ comment|markdownify }}`
After: `{{ comment|markdownify|linebreaksbr }}`

## (If editing Django app) Please add screenshots

```
"comment": "Examples: let scores : (string | number)[];\nlet nums : number[] = [12.34,1,2,3];\nlet arr : Array = [1,2,3,'hi'];\nlet arr : Array<number|boolean> = [1, true, 2];"
```

[Before]
![image](https://user-images.githubusercontent.com/15680274/138537324-ad72aa4e-301f-4601-a1bd-8588d7da9473.png)

[After]
![image](https://user-images.githubusercontent.com/15680274/138537335-37072aa6-8e13-401e-840a-1f0e30b1d5e4.png)

## Checklist

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [x] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?
