### PR TITLE
Fix logical vs bitwise AND/OR/NOT/etc. operators in meta language file

### DIFF
--- a/web/thesauruses/_meta/operators.json
+++ b/web/thesauruses/_meta/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,25 +36,31 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
       "right_shift_assignment"
     ],
-    "Conditional Operators": ["ternary", "null_forgiving"]
+    "Conditional Operators": [
+      "ternary",
+      "null_forgiving"
+    ]
   },
   "operators": {
     "addition": {
@@ -173,44 +179,56 @@
       "name": "Is not operator",
       "code": [""]
     },
-    "and": {
+    "logical_and": {
       "name": "Logical AND operator",
       "code": [""]
     },
-    "and_assignment": {
-      "name": "Logical AND assignment operator",
-      "code": [""]
-    },
-    "or": {
+    "logical_or": {
       "name": "Logical OR operator",
       "code": [""]
     },
-    "or_assignment": {
-      "name": "Logical OR assignment operator",
-      "code": [""]
-    },
-    "not": {
+    "logical_not": {
       "name": "Logical NOT operator",
       "code": [""]
     },
+    "bitwise_and": {
+      "name": "Bitwise AND operator",
+      "code": [""]
+    },
+    "bitwise_and_assignment": {
+      "name": "Bitwise AND and assignment operator",
+      "code": [""]
+    },
+    "bitwise_or": {
+      "name": "Bitwise OR operator",
+      "code": [""]
+    },
+    "bitwise_or_assignment": {
+      "name": "Bitwise OR and assignment operator",
+      "code": [""]
+    },
+    "bitwise_not": {
+      "name": "Bitwise NOT operator",
+      "code": [""]
+    },
     "not_assignment": {
-      "name": "Logical NOT assignment operator",
+      "name": "Bitwise NOT and assignment operator",
       "code": [""]
     },
-    "xor": {
-      "name": "Logical XOR operator",
+    "bitwise_xor": {
+      "name": "Bitwise XOR operator",
       "code": [""]
     },
-    "xor_assignment": {
-      "name": "Logical XOR assignment operator",
+    "bitwise_xor_assignment": {
+      "name": "Bitwise XOR and assignment operator",
       "code": [""]
     },
-    "xnor": {
-      "name": "Logical XNOR operator",
+    "bitwise_xnor": {
+      "name": "Bitwise XNOR operator",
       "code": [""]
     },
-    "xnor_assignment": {
-      "name": "Logical XNOR assignment operator",
+    "bitwise_xnor_assignment": {
+      "name": "Bitwise XNOR and assignment operator",
       "code": [""]
     },
     "left_shift": {

--- a/web/thesauruses/ada/operators.json
+++ b/web/thesauruses/ada/operators.json
@@ -17,23 +17,35 @@
       "exponential",
       "absolute_value"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
       "less_than_or_equal_to",
       "greater_than",
       "greater_than_or_equal_to",
+      "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "or",
-      "not",
-      "xor",
-		"left_shift",
-      "right_shift"
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
+      "left_shift",
+      "left_shift_assignment",
+      "right_shift",
+      "right_shift_assignment"
     ],
     "Conditional Operators": []
   },
@@ -129,40 +141,6 @@
     },
     "is_not": {
       "code": "x not in y"
-    },
-    "and": {
-      "code": "ans := ((x > y) and (y = x)) \n Byte_IO.Put (Item => x and y, Base => r)",
-      "comment": "Method 1, returns boolean value i.e TRUE/FALSE. Method 2 (requires Byte_IO package and interfaces), returns value of base r(any natural value) and is only applicable for modular types."
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "ans := ((x > y) or (y = x)) \n Byte_IO.Put (Item => x or y, Base => r)",
-      "comment": "Method 1, returns boolean value i.e TRUE/FALSE. Method 2 (requires Byte_IO package and interfaces), returns value of base r(any natural value) and is only applicable for modular types."
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "ans := not x \n Byte_IO.Put (Item => not x, Base => r)",
-      "comment": "Method 1,returns boolean value i.e TRUE/FALSE when x is a boolean value. Method 2 (requires Byte_IO package and interfaces), returns value of base r(any natural value) and is only applicable for modular types."
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "ans := ((x > y) xor (y = x)) \n Byte_IO.Put (Item => A xor B, Base => r)",
-      "comment": "Method 1, returns boolean value i.e TRUE/FALSE. Method 2 (requires Byte_IO package and interfaces), returns value of base r(any natural value) and is only applicable for modular types."
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
-      "not-implemented": "true"
     },
     "left_shift": {
 		"code":"Shift_Left (x, n)",

--- a/web/thesauruses/bash/operators.json
+++ b/web/thesauruses/bash/operators.json
@@ -23,7 +23,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -32,19 +32,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -128,36 +131,6 @@
       "not-implemented": "true"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "expression1 && expressions2"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "expression1 || expressions2"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "!expression"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "(( a^b ))"
-    },
-    "xor_assignment": {
-      "code": "(( a^=3 ))"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/cpp/operators.json
+++ b/web/thesauruses/cpp/operators.json
@@ -23,7 +23,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -32,19 +32,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -131,36 +134,6 @@
       "not-implemented": "true"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "&&"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "||"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "!"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "^"
-    },
-    "xor_assignment": {
-      "code": "^="
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/csharp/operators.json
+++ b/web/thesauruses/csharp/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,19 +36,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -145,36 +148,6 @@
       "code": "is"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "&"
-    },
-    "and_assignment": {
-      "code": "&="
-    },
-    "or": {
-      "code": "|"
-    },
-    "or_assignment": {
-      "code": "|="
-    },
-    "not": {
-      "code": "!"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "^"
-    },
-    "xor_assignment": {
-      "code": "^="
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/haskell/operators.json
+++ b/web/thesauruses/haskell/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,19 +36,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -158,42 +161,6 @@
     },
     "is_not": {
       "comment": "Haskell doesn't have a notion of identity/reference equality.",
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "x && y"
-    },
-    "and_assignment": {
-      "comment": "Haskell is a functional language, so it does not allow variable reassignment.",
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "x || y"
-    },
-    "or_assignment": {
-      "comment": "Haskell is a functional language, so it does not allow variable reassignment.",
-      "not-implemented": "true"
-    },
-    "not": {
-      "comment": "There are 2 valid logical not operators in Haskell.",
-      "code": "x /= y \nnot x"
-    },
-    "not_assignment": {
-      "comment": "Haskell is a functional language, so it does not allow variable reassignment.",
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "",
-      "not-implemented": "true"
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "code": "x == y"
-    },
-    "xnor_assignment": {
-      "comment": "Haskell is a functional language, so it does not allow variable reassignment.",
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/java/operators.json
+++ b/web/thesauruses/java/operators.json
@@ -23,7 +23,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -32,19 +32,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -126,36 +129,6 @@
       "not-implemented": "true"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "&&"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "||"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "!"
-    },
-    "not_assignment": {
-      "code": "!="
-    },
-    "xor": {
-      "code": "^"
-    },
-    "xor_assignment": {
-      "code": "^="
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/javascript/operators.json
+++ b/web/thesauruses/javascript/operators.json
@@ -23,7 +23,7 @@
 			"absolute_value",
 			"percentage"
 		],
-		"Equality/Comparison Operators": [
+		"Equality/Comparison/Logical Operators": [
 			"equal_to",
 			"not_equal_to",
 			"less_than",
@@ -32,19 +32,22 @@
 			"greater_than_or_equal_to",
 			"null_coalescing",
 			"is",
-			"is_not"
+			"is_not",
+			"logical_and",
+			"logical_or",
+			"logical_not"
 		],
-		"Logical/Boolean/Bitwise Operators": [
-			"and",
-			"and_assignment",
-			"or",
-			"or_assignment",
-			"not",
-			"not_assignment",
-			"xor",
-			"xor_assignment",
-			"xnor",
-			"xnor_assignment",
+		"Bitwise Operators": [
+			"bitwise_and",
+			"bitwise_and_assignment",
+			"bitwise_or",
+			"bitwise_or_assignment",
+			"bitwise_not",
+			"bitwise_not_assignment",
+			"bitwise_xor",
+			"bitwise_xor_assignment",
+			"bitwise_xnor",
+			"bitwise_xnor_assignment",
 			"left_shift",
 			"left_shift_assignment",
 			"right_shift",
@@ -128,36 +131,6 @@
 			"not-implemented": "true"
 		},
 		"is_not": {
-			"not-implemented": "true"
-		},
-		"and": {
-			"code": "&&"
-		},
-		"and_assignment": {
-			"code": "&="
-		},
-		"or": {
-			"code": "||"
-		},
-		"or_assignment": {
-			"not-implemented": "true"
-		},
-		"not": {
-			"code": "!"
-		},
-		"not_assignment": {
-			"not-implemented": "true"
-		},
-		"xor": {
-			"code": "&"
-		},
-		"xor_assignment": {
-			"code": "^="
-		},
-		"xnor": {
-			"not-implemented": "true"
-		},
-		"xnor_assignment": {
 			"not-implemented": "true"
 		},
 		"left_shift": {

--- a/web/thesauruses/nim/operators.json
+++ b/web/thesauruses/nim/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,19 +36,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -147,36 +150,6 @@
     },
     "is_not": {
       "code": "isnot"
-    },
-    "and": {
-      "code": "and"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "or"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "not"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "xor"
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
-      "not-implemented": "true"
     },
     "left_shift": {
       "code": "shl"

--- a/web/thesauruses/objectivec/operators.json
+++ b/web/thesauruses/objectivec/operators.json
@@ -25,7 +25,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -34,19 +34,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -148,40 +151,6 @@
       "not-implemented": "true"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "&&",
-      "comment": "If both operands are non-zero/true then statement is true else false."
-    },
-    "and_assignment": {
-      "code": "&&="
-    },
-    "or": {
-      "code": "||",
-      "comment": "If any operand is non-zero/true then statement is true else false."
-    },
-    "or_assignment": {
-      "code": "||="
-    },
-    "not": {
-      "code": "!",
-      "comment": "If operand is true then returns false and vice-versa"
-    },
-    "not_assignment": {
-      "code": "=!"
-    },
-    "xor": {
-      "code": "int a = 4 ^ 6 \n",
-      "comment": "It is a bitwise operator. It copies the bit if it is set in one operand but not both. Value of a is 2"
-    },
-    "xor_assignment": {
-      "code": "^="
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/perl/operators.json
+++ b/web/thesauruses/perl/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,19 +36,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -151,38 +154,6 @@
       "not-implemented": true
     },
     "is_not": {
-      "not-implemented": true
-    },
-    "and": {
-      "code": "and",
-      "comment": "Alternative C like option is: &&"
-    },
-    "and_assignment": {
-      "not-implemented": true
-    },
-    "or": {
-      "code": "or",
-      "comment": "Alternative C like option is: ||"
-    },
-    "or_assignment": {
-      "not-implemented": true
-    },
-    "not": {
-      "code": "not"
-    },
-    "not_assignment": {
-      "not-implemented": true
-    },
-    "xor": {
-      "code": "xor"
-    },
-    "xor_assignment": {
-      "not-implemented": true
-    },
-    "xnor": {
-      "not-implemented": true
-    },
-    "xnor_assignment": {
       "not-implemented": true
     },
     "left_shift": {

--- a/web/thesauruses/php/operators.json
+++ b/web/thesauruses/php/operators.json
@@ -24,22 +24,35 @@
       "exponential",
       "absolute_value"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
       "less_than_or_equal_to",
       "greater_than",
       "greater_than_or_equal_to",
-      "null_coalescing"
+      "null_coalescing",
+      "is",
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "or",
-      "not",
-      "xor",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
-      "right_shift"
+      "left_shift_assignment",
+      "right_shift",
+      "right_shift_assignment"
     ],
     "Conditional Operators": ["ternary"]
   },
@@ -115,20 +128,6 @@
     },
     "null_coalescing": {
       "code": "$operand1 ?? $operand2"
-    },
-    "and": {
-      "code": "$operand1 and $operand2 \n  $operand1 && $operand2",
-      "comment": "You can use any of them"
-    },
-    "or": {
-      "code": "$operand1 or $operand2 \n  $operand1 || $operand2",
-      "comment": "You can use any of them"
-    },
-    "not": {
-      "code": "!$operand1"
-    },
-    "xor": {
-      "code": "^$operand1"
     },
     "left_shift": {
       "code": "<<$operand1"

--- a/web/thesauruses/python/operators.json
+++ b/web/thesauruses/python/operators.json
@@ -23,7 +23,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -32,19 +32,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -130,36 +133,6 @@
     },
     "is_not": {
       "code": "is not"
-    },
-    "and": {
-      "code": "and"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "or"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "not"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "^"
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
-      "not-implemented": "true"
     },
     "left_shift": {
       "code": "<<"

--- a/web/thesauruses/rust/operators.json
+++ b/web/thesauruses/rust/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,19 +36,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -148,36 +151,6 @@
       "not-implemented": "true"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "&&"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "||"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "!"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "not-implemented": "true"
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/scala/operators.json
+++ b/web/thesauruses/scala/operators.json
@@ -27,7 +27,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -36,19 +36,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -149,36 +152,6 @@
     "is_not": {
       "not-implemented": "true"
     },
-    "and": {
-      "code": "&&"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "||"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "!"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "^"
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
-      "not-implemented": "true"
-    },    
     "left_shift": {
       "code": "<<"
     },

--- a/web/thesauruses/swift/operators.json
+++ b/web/thesauruses/swift/operators.json
@@ -23,7 +23,7 @@
       "absolute_value",
       "percentage"
     ],
-    "Equality/Comparison Operators": [
+    "Equality/Comparison/Logical Operators": [
       "equal_to",
       "not_equal_to",
       "less_than",
@@ -32,19 +32,22 @@
       "greater_than_or_equal_to",
       "null_coalescing",
       "is",
-      "is_not"
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
     ],
-    "Logical/Boolean/Bitwise Operators": [
-      "and",
-      "and_assignment",
-      "or",
-      "or_assignment",
-      "not",
-      "not_assignment",
-      "xor",
-      "xor_assignment",
-      "xnor",
-      "xnor_assignment",
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
       "left_shift",
       "left_shift_assignment",
       "right_shift",
@@ -131,36 +134,6 @@
       "not-implemented": "true"
     },
     "is_not": {
-      "not-implemented": "true"
-    },
-    "and": {
-      "code": "&&"
-    },
-    "and_assignment": {
-      "not-implemented": "true"
-    },
-    "or": {
-      "code": "||"
-    },
-    "or_assignment": {
-      "not-implemented": "true"
-    },
-    "not": {
-      "code": "!"
-    },
-    "not_assignment": {
-      "not-implemented": "true"
-    },
-    "xor": {
-      "code": "^"
-    },
-    "xor_assignment": {
-      "not-implemented": "true"
-    },
-    "xnor": {
-      "not-implemented": "true"
-    },
-    "xnor_assignment": {
       "not-implemented": "true"
     },
     "left_shift": {

--- a/web/thesauruses/typescript/operators.json
+++ b/web/thesauruses/typescript/operators.json
@@ -23,33 +23,36 @@
 			"absolute_value",
 			"percentage"
 		],
-		"Equality/Comparison Operators": [
-			"equal_to",
-			"not_equal_to",
-			"less_than",
-			"less_than_or_equal_to",
-			"greater_than",
-			"greater_than_or_equal_to",
-			"null_coalescing",
-			"is",
-			"is_not"
-		],
-		"Logical/Boolean/Bitwise Operators": [
-			"and",
-			"and_assignment",
-			"or",
-			"or_assignment",
-			"not",
-			"not_assignment",
-			"xor",
-			"xor_assignment",
-			"xnor",
-			"xnor_assignment",
-			"left_shift",
-			"left_shift_assignment",
-			"right_shift",
-			"right_shift_assignment"
-		],
+    "Equality/Comparison/Logical Operators": [
+      "equal_to",
+      "not_equal_to",
+      "less_than",
+      "less_than_or_equal_to",
+      "greater_than",
+      "greater_than_or_equal_to",
+      "null_coalescing",
+      "is",
+      "is_not",
+      "logical_and",
+      "logical_or",
+      "logical_not"
+    ],
+    "Bitwise Operators": [
+      "bitwise_and",
+      "bitwise_and_assignment",
+      "bitwise_or",
+      "bitwise_or_assignment",
+      "bitwise_not",
+      "bitwise_not_assignment",
+      "bitwise_xor",
+      "bitwise_xor_assignment",
+      "bitwise_xnor",
+      "bitwise_xnor_assignment",
+      "left_shift",
+      "left_shift_assignment",
+      "right_shift",
+      "right_shift_assignment"
+    ],
 		"Conditional Operators": ["ternary", "null_forgiving"]
 	},
 	"operators": {
@@ -128,36 +131,6 @@
 			"not-implemented": "true"
 		},
 		"is_not": {
-			"not-implemented": "true"
-		},
-		"and": {
-			"code": "&&"
-		},
-		"and_assignment": {
-			"code": "&="
-		},
-		"or": {
-			"code": "||"
-		},
-		"or_assignment": {
-			"not-implemented": "true"
-		},
-		"not": {
-			"code": "!"
-		},
-		"not_assignment": {
-			"not-implemented": "true"
-		},
-		"xor": {
-			"code": "&"
-		},
-		"xor_assignment": {
-			"code": "^="
-		},
-		"xnor": {
-			"not-implemented": "true"
-		},
-		"xnor_assignment": {
 			"not-implemented": "true"
 		},
 		"left_shift": {


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->


## What GitHub issue does this PR apply to?

<!-- Replace "xxxx" below with the issue number.  -->
<!-- You can change it to say only "Closes #", "Fixes #", or "Resolves #". -->
<!-- Don't add the word "issue" to it otherwise it won't link. -->

Resolves #333 


## What changed and why?

Modified _meta/operators.json to correctly reflect AND/OR/NOT operators to be logical or bitwise (before it didn't really have that distinction.)


## (If editing Django app) Please add screenshots

<!-- Please copy screenshots, then replace this line by pasting screenshots here -->
<!-- If this doesn't apply, you can delete this header and section. -->


## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

<!-- Please replace this line with any comments -->

