### PR TITLE
Remove language categories as they're no longer needed after PR #448

### DIFF
--- a/web/Language.py
+++ b/web/Language.py
@@ -12,7 +12,6 @@ class Language:
         # Add an empty string to convert SafeString to str
         self.key = str(key + "")
         self.friendly_name = None
-        self.categories = None
         self.concepts = None
 
     def has_key(self):
@@ -44,7 +43,6 @@ class Language:
             file_json = json.loads(data)
 
             self.friendly_name = file_json["meta"]["language_name"]
-            self.categories = file_json["categories"]
             self.concepts = file_json[structure_key]
 
     def concept(self, concept_key):

--- a/web/tests/test_meta_structures.py
+++ b/web/tests/test_meta_structures.py
@@ -41,7 +41,6 @@ class TestMetaStructures(TestCase):
 		self.assertIsNotNone(language)
 		self.assertIsNotNone(language.key)
 		self.assertIsNone(language.friendly_name)
-		self.assertIsNone(language.categories)
 		self.assertIsNone(language.concepts)
 
 	def test_language_bad_key_and_lang_exists(self):
@@ -71,14 +70,12 @@ class TestMetaStructures(TestCase):
 		language_id = "abcdefg"
 		language_friendly_name = "Alphabet language!"
 
-		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
 		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
 		# This is like the manual work of calling language.load_structure()
 		language.friendly_name = language_friendly_name
-		language.categories = categories
 		language.concepts = concepts
 
 		# 	# Test unknown concept
@@ -96,14 +93,12 @@ class TestMetaStructures(TestCase):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
-		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
 		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
 		# This is like the manual work of calling language.load_structure()
 		language.friendly_name = langauge_friendly_name
-		language.categories = categories
 		language.concepts = concepts
 
 		# Test unknown concept
@@ -118,14 +113,12 @@ class TestMetaStructures(TestCase):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
-		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
 		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
 		# This is like the manual work of calling language.load_structure()
 		language.friendly_name = langauge_friendly_name
-		language.categories = categories
 		language.concepts = concepts
 
 		# Test unknown concept
@@ -141,14 +134,12 @@ class TestMetaStructures(TestCase):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
-		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
 		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
 		# This is like the manual work of calling language.load_structure()
 		language.friendly_name = langauge_friendly_name
-		language.categories = categories
 		language.concepts = concepts
 
 		# Test unknown concept
@@ -164,14 +155,12 @@ class TestMetaStructures(TestCase):
 		language_id = "abcdefg"
 		langauge_friendly_name = "Alphabet language!"
 
-		categories = json.loads("{\"category1\": [\"concept1\",\"concept2\",\"concept3\"]}")
 		concepts = json.loads("{\"concept1\": {\"code\": \"abc\"},\"concept2\": {\"code\": \"abc\",\"comment\": \"My comment\"},\"concept3\":{\"not-implemented\": \"true\"},\"concept4\":{\"code\":[\"line1\",\"line2\"]}}")
 
 		language = Language(language_id)
 
 		# This is like the manual work of calling language.load_structure()
 		language.friendly_name = langauge_friendly_name
-		language.categories = categories
 		language.concepts = concepts
 
 		# Test unknown concept


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->


## What GitHub issue does this PR apply to?

N/A

## What changed and why?

The original thesaurus matching algorithm used the categories from the first language file. This shouldn't have been the case as it meant if two languages had different (or missing) categories, or if they didn't match the meta language's categories, it could error or possible show up wrong. PR #448 fixes this so categories are loaded from the meta files instead of language files.

This PR will fix the residual issue that categories _still_ had to be in the language files as they were loaded in. The `Language` class still loaded them, and removing them made CT think the language didn't exist. This removes the categories from the `Language` (but leaves them in `MetaLanguage`) so that CT can still render without the language JSON files needing categories.

This doesn't remove the categories from the JSON files. That can be done later.

This also removes the parts of tests that tested categories and is no longer needed either.

## (If editing Django app) Please add screenshots

The app appears the same, therefore there's no screenshots.

## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [x] (If editing Django) I have added or edited any appropriate unit tests for my changes

