### PR TITLE
[Fix issue #463] "Back to top" arrow and "Made by" info are arranged weird when viewed on mobile

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -62,11 +62,11 @@
 <footer class="text-muted">
     <div class="container">
         <div class="row">
-          <div class="col">
+          <div class="col-8 justify-content-start">
             <p>Made with &#x2764; by Sarah Withee and <a href="https://github.com/codethesaurus/codethesaur.us/graphs/contributors" target="_blank" rel="noreferrer"><span id="contributors"></span> contributors</a>.</p> <!-- x2764 the heart emoji code -->
             <p>Want to help out? Check the project out on <a href="http://github.com/codethesaurus/" target="_blank" rel="noopener">GitHub</a>.</p>
           </div>
-          <div class="col order-sm-2 d-flex justify-content-end align-self-center">
+          <div class="col-4 order-sm-2 d-flex justify-content-end align-self-center">
               <div class="flex-column">
                   <a class="toTop" href="#">
                       <span class="d-flex flex-column">

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -62,20 +62,20 @@
 <footer class="text-muted">
     <div class="container">
         <div class="row">
-            <div class="col order-sm-2 d-flex justify-content-end align-self-center">
-                <div class="flex-column">
-                    <a class="toTop" href="#">
-                        <span class="d-flex flex-column">
-                            <i class="fa fa-angle-up fa-2x align-self-center" aria-hidden="true"></i>
-                            Back to top
-                        </span>
-                    </a>
-                </div>
-            </div>
-            <div class="col">
-                <p>Made with &#x2764; by Sarah Withee and <a href="https://github.com/codethesaurus/codethesaur.us/graphs/contributors" target="_blank" rel="noreferrer"><span id="contributors"></span> contributors</a>.</p> <!-- x2764 the heart emoji code -->
-                <p>Want to help out? Check the project out on <a href="http://github.com/codethesaurus/" target="_blank" rel="noopener">GitHub</a>.</p>
-            </div>
+          <div class="col">
+            <p>Made with &#x2764; by Sarah Withee and <a href="https://github.com/codethesaurus/codethesaur.us/graphs/contributors" target="_blank" rel="noreferrer"><span id="contributors"></span> contributors</a>.</p> <!-- x2764 the heart emoji code -->
+            <p>Want to help out? Check the project out on <a href="http://github.com/codethesaurus/" target="_blank" rel="noopener">GitHub</a>.</p>
+          </div>
+          <div class="col order-sm-2 d-flex justify-content-end align-self-center">
+              <div class="flex-column">
+                  <a class="toTop" href="#">
+                      <span class="d-flex flex-column">
+                          <i class="fa fa-angle-up fa-2x align-self-center" aria-hidden="true"></i>
+                          Back to top
+                      </span>
+                  </a>
+              </div>
+          </div>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->


## What GitHub issue does this PR apply to?

<!-- Replace "xxxx" below with the issue number.  -->
<!-- You can change it to say only "Closes #", "Fixes #", or "Resolves #". -->
<!-- Don't add the word "issue" to it otherwise it won't link. -->

Resolves #463


## What changed and why?

Switched the two `<div class="col">` elements which caused the "Back to Top" and "Made by" to be rendered in a backwards manner. As a result, the rendered elements did not respect the bootstrap column system.

## (If editing Django app) Please add screenshots

![screenshot of fixed page](https://user-images.githubusercontent.com/10303302/150720634-0fd082c7-c2f1-45d9-9d6e-7ce859dc92c9.png)


## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

<!-- Please replace this line with any comments -->

