### PR TITLE
Adds Twitter metadata for better Slack unfurls

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -13,6 +13,21 @@
     <meta property="og:url" content="{{ request.build_absolute_uri }}" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}/static/images/Logo-Book-Code.png" />
+    
+    <!-- Twitter, Slack, etc. -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@CodeThesaurus">
+    <meta name="twitter:title" content="Code Thesaurus - {{ title }}">
+    <meta name="twitter:description" content="{{ description }}">
+    <meta name="twitter:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}/static/images/Logo-Book-Code.png">
+    <meta name="twitter:image:alt" content="Code Thesarus logo">
+    <!-- TODO: make these show number of languages/examples? -->
+    <!--
+    <meta name="twitter:label1" content="">
+    <meta name="twitter:data1" content="">
+    <meta name="twitter:label2" content="">
+    <meta name="twitter:data2" content="">
+    -->
 
     <title>Code Thesaurus - {{ title }}</title>
 


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

None!

## What changed and why?

Adds Twitter metadata for better Slack unfurls. Slack uses Twitter metadata when available and seems to display it better than OpenGraph.

## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [ ] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

I made this change in GitHub so I'm not 100% certain of its functionality. It passes my smell test and it's copied from an app that appropriately renders HTML and the data in the fields, so chance of error is basically just "did I mess up putting things inside the 
`content` attribute 🙃 