### PR TITLE
add handle to support 100+ contributors on footer

### DIFF
--- a/web/static/js/contributors.js
+++ b/web/static/js/contributors.js
@@ -1,5 +1,22 @@
-$(document).ready(function(){
-  jQuery.get('https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vnd.github.v3+json&per_page=100&anon=1', function(data, status){
-    $("#contributors").text(data.length)
-  })
-})
+$(document).ready(function () {
+  let i = 1;
+  let length = 0;
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const timer = async () => {
+    await sleep(1000);
+    jQuery
+      .get(
+        `https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vnd.github.v3+json&per_page=100&page=${i}&anon=1`
+      )
+      .then((data) => {
+        length += data.length;
+        i++;
+        if (data.length === 0) {
+          $("#contributors").text(length);
+        } else {
+          timer();
+        }
+      });
+  };
+  timer();
+});

--- a/web/static/js/contributors.js
+++ b/web/static/js/contributors.js
@@ -1,9 +1,7 @@
 $(document).ready(function () {
   let i = 1;
   let length = 0;
-  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
   const timer = async () => {
-    await sleep(1000);
     jQuery
       .get(
         `https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vnd.github.v3+json&per_page=100&page=${i}&anon=1`
@@ -14,7 +12,7 @@ $(document).ready(function () {
         if (data.length === 0) {
           $("#contributors").text(length);
         } else {
-          timer();
+          setTimeout(timer, 500);
         }
       });
   };


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->


## What GitHub issue does this PR apply to?

<!-- Replace "xxxx" below with the issue number.  -->
<!-- You can change it to say only "Closes #", "Fixes #", or "Resolves #". -->
<!-- Don't add the word "issue" to it otherwise it won't link. -->

Resolves #465


## What changed and why?

The GitHub API limits calls to 100 contributors per "page", and only one page of results was being fetched. Updated function to make additional API calls when there are > 100 contributors.

## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

<!-- Please replace this line with any comments -->

