### PR TITLE
removing jquery dependency

### DIFF
--- a/web/static/js/contributors.js
+++ b/web/static/js/contributors.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   contributorsRequest.onload = function () {
     if (contributorsRequest.status != 200) {
-      document.querySelector("#contributors").innerHTML = 0;
+      document.querySelector("#contributors").innerHTML = "multiple";
       return;
     }
 
@@ -19,11 +19,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
       document.querySelector("#contributors").innerHTML = response.length;
     } catch {
-      document.querySelector("#contributors").innerHTML = 0;
+      document.querySelector("#contributors").innerHTML = "multiple";
     }
   };
 
   contributorsRequest.onerror = function () {
-    document.querySelector("#contributors").innerHTML = 0;
+    document.querySelector("#contributors").innerHTML = "multiple";
   };
 });

--- a/web/static/js/contributors.js
+++ b/web/static/js/contributors.js
@@ -23,11 +23,12 @@ document.addEventListener("DOMContentLoaded", function () {
       try {
         var response = JSON.parse(contributorsRequest.response);
 
-        if (!response.length) {
+        numberOfContributors += response.length;
+
+        if (response.length < 100) {
           document.querySelector("#contributors").innerHTML =
             numberOfContributors;
         } else {
-          numberOfContributors += response.length;
           currentPage++;
           getContributors();
         }

--- a/web/static/js/contributors.js
+++ b/web/static/js/contributors.js
@@ -1,5 +1,29 @@
-$(document).ready(function(){
-  jQuery.get('https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vnd.github.v3+json&per_page=100&anon=1', function(data, status){
-    $("#contributors").text(data.length)
-  })
-})
+document.addEventListener("DOMContentLoaded", function () {
+  var contributorsRequest = new XMLHttpRequest();
+
+  contributorsRequest.open(
+    "GET",
+    "https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vd.github.v3+json&per_page=200&anon=1"
+  );
+
+  contributorsRequest.send();
+
+  contributorsRequest.onload = function () {
+    if (contributorsRequest.status != 200) {
+      document.querySelector("#contributors").innerHTML = 0;
+      return;
+    }
+
+    try {
+      var response = JSON.parse(contributorsRequest.response);
+
+      document.querySelector("#contributors").innerHTML = response.length;
+    } catch {
+      document.querySelector("#contributors").innerHTML = 0;
+    }
+  };
+
+  contributorsRequest.onerror = function () {
+    document.querySelector("#contributors").innerHTML = 0;
+  };
+});

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -96,7 +96,6 @@
 </footer>
 
 <!--scripts loaded here-->
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 <script src="/static/js/contributors.js"></script>
 


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Resolves #482

## What changed and why?

- Removed Jquery import from `base.html`
- changed `contributors.js` to use XMLHttpRequest to get the request from github.
- added error handling in case the request gets messed up somehow, by setting contributors to 0 (only if the data is not available)
- increased the `per_page` attribute from the url, because the repo is nearing 100 contributors!

## Checklist

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work