### PR TITLE
Fix links to contribute

### DIFF
--- a/web/templates/compare.html
+++ b/web/templates/compare.html
@@ -54,14 +54,14 @@
                 </div>
                 <div class="card" id="start-of-row">
                     <div class="card-body">
-                        <a href="https://github.com/codethesaurus/codethesaur.us/edit/main/web/thesauruses/{{ lang1 }}/{{ concept }}.json">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/edit/main/web/thesauruses/{{ lang1 }}/{{ version1 }}/{{ concept }}.json">
                             Want to add or correct information for {{ lang1_friendlyname }}?
                         </a>
                     </div>
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <a href="https://github.com/codethesaurus/codethesaur.us/edit/main/web/thesauruses/{{ lang2 }}/{{ concept }}.json">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/edit/main/web/thesauruses/{{ lang2 }}/{{ version2 }}/{{ concept }}.json">
                             Want to add or correct information for {{ lang2_friendlyname }}?
                         </a>
                     </div>

--- a/web/templates/reference.html
+++ b/web/templates/reference.html
@@ -47,7 +47,7 @@
                 </div>
                 <div class="card" id="start-of-row">
                     <div class="card-body">
-                        <a href="https://github.com/codethesaurus/codethesaur.us/edit/main/web/thesauruses/{{ lang }}/{{ concept }}.json">
+                        <a href="https://github.com/codethesaurus/codethesaur.us/edit/main/web/thesauruses/{{ lang }}/{{ version }}/{{ concept }}.json">
                             Want to add or correct information for {{ lang_friendlyname }}?
                         </a>
                     </div>

--- a/web/views.py
+++ b/web/views.py
@@ -269,7 +269,6 @@ def reference(request):
     try:
         lang = meta_info.language(lang_string)
         lang.load_concepts(meta_structure.key, version)
-        # import pdb; pdb.set_trace()
     except FileNotFoundError:
         ctx = {
             "name": meta_structure.friendly_name,

--- a/web/views.py
+++ b/web/views.py
@@ -214,6 +214,8 @@ def compare(request):
         "concept_friendly_name": meta_structure.friendly_name,
         "lang1": lang1.key,
         "lang2": lang2.key,
+        "version1": version1,
+        "version2": version2,
         "lang1_friendlyname": lang1.friendly_name,
         "lang2_friendlyname": lang2.friendly_name,
         "categories": both_categories,
@@ -267,6 +269,7 @@ def reference(request):
     try:
         lang = meta_info.language(lang_string)
         lang.load_concepts(meta_structure.key, version)
+        # import pdb; pdb.set_trace()
     except FileNotFoundError:
         ctx = {
             "name": meta_structure.friendly_name,
@@ -306,6 +309,7 @@ def reference(request):
         "concept": meta_structure.key,
         "concept_friendly_name": meta_structure.friendly_name,
         "lang": lang.key,
+        "version": version,
         "lang_friendlyname": lang.friendly_name,
         "categories": categories,
         "description": f"Code Thesaurus: Reference for {lang.key}"


### PR DESCRIPTION
## What GitHub issue does this PR apply to?
https://github.com/codethesaurus/codethesaur.us/issues/484

Resolves #484

## What changed and why?

Adds version numbers to language data returned from `views.py` and adds them to the html templates.


## (If editing Django app) Please add screenshots
Here's a link that was previously broken 🎉:
https://user-images.githubusercontent.com/63751206/167378875-fe056d29-15da-48fd-bcb5-2769762d745e.mov



## Checklist

<!-- Either add an X inside the [ ], or submit the PR and click the checkboxes. -->

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes

## Any additional comments or things to be aware of while reviewing?

This would be awesome to test... the two ways to do this that I can think of are (a) pinging the URLs to see if the link actually gets a 200 or (b) read the file paths in `/thesauruses/` and see that they match the patterns in the generated URLs. Both feel overkill... if you think of a way (or if either of those seem worth it) I'm happy to tinker!

