### PR TITLE
Fix broken generate_templates command

### DIFF
--- a/web/management/commands/generate_template.py
+++ b/web/management/commands/generate_template.py
@@ -1,7 +1,8 @@
 from django.core.management.base import BaseCommand
 
 from web.thesaurus_template_generators import generate_language_template
-from web.MetaInfo import MetaInfo
+from web.models import MetaInfo
+from packaging.version import parse as parse_version
 
 import os
 
@@ -10,7 +11,7 @@ class Command(BaseCommand):
     help = 'Generate language thesaurus files to be filled out'
 
     def add_arguments(self, parser):
-        structures = list(MetaInfo().data_structures.keys())
+        structures = list(MetaInfo().structures.keys())
 
         parser.add_argument('language', help="Id of the programming language")
         parser.add_argument(
@@ -19,7 +20,7 @@ class Command(BaseCommand):
                 help="Id(s) of the structure(s)",
                 choices=structures
                 )
-        parser.add_argument('--language-version')
+        parser.add_argument('--language-version', required=True)
 
     def handle(self, *args, **options):
         for structure in options['structures']:
@@ -37,6 +38,8 @@ class Command(BaseCommand):
                     f'The structure "{structure}" is not implemented yet. You can visit https://docs.codethesaur.us/thesaurus/ to learn how to add one.'
             )
 
+        version = parse_version(language_version)
+        major_version = version.major
         language_dir_path = os.path.join(
             'web',
             'thesauruses',
@@ -44,11 +47,26 @@ class Command(BaseCommand):
         )
 
         if not os.path.exists(language_dir_path):
-            self.stdout.write(f'NOTE: The language "{language}" did not exist yet, make sure to add it in "web/thesauruses/meta_info.json" and adjust "language_name" in the "meta" section or it will not be picked up!')
+            warn = self.style.WARNING
+            self.stdout.write(
+                f'{warn("NOTE:")} The language "{language}" '\
+                 'did not exist yet, make sure to add it in '\
+                f'"{warn("web/thesauruses/meta_info.json")}" and adjust '\
+                 '"language_name" in the "meta" section or it will not be '\
+                 'picked up!\n\n'
+            )
             os.mkdir(language_dir_path)
 
-        template_file_path = os.path.join(
+        template_file_directory = os.path.join(
             language_dir_path,
+            f'{major_version}'
+        )
+
+        if not os.path.exists(template_file_directory):
+            os.mkdir(template_file_directory)
+
+        template_file_path = os.path.join(
+            template_file_directory,
             f"{structure}.json"
         )
 
@@ -59,4 +77,7 @@ class Command(BaseCommand):
             with open(template_file_path, 'w') as file:
                 file.write(template)
             self.stdout.write(
-                f'Created template file "{template_file_path}" which you can now edit.')
+                 'Created template file '\
+                f'"{self.style.SUCCESS(template_file_path)}" which you can '\
+                 'now edit.'
+            )


### PR DESCRIPTION
## What changed and why?

   generate_templates was still using old `web.MetaInfo` module, update it to work with the `models` one.


## Checklist

   <!-- 
   Each - [ ] below is a checkbox that will show up on the PR.
   Either add an X inside the [X], or submit the PR and click the checkboxes.
   -->

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

   <!-- Please replace this line with any extra information that's helpful -->

