### PR TITLE
Improve contributors.js to fetch the number in a single request

### DIFF
--- a/web/static/js/contributors.js
+++ b/web/static/js/contributors.js
@@ -1,46 +1,29 @@
 document.addEventListener("DOMContentLoaded", function () {
-  var currentPage = 1;
-  var numberOfContributors = 0;
-
-  function getContributors() {
     var contributorsRequest = new XMLHttpRequest();
 
     contributorsRequest.open(
-      "GET",
-      "https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vd.github.v3+json&per_page=100&page=" +
-        currentPage +
-        "&anon=1"
+        "GET",
+        "https://api.github.com/repos/codethesaurus/codethesaur.us/contributors?accept=application/vd.github.v3+json&per_page=1&anon=1"
     );
 
     contributorsRequest.send();
 
     contributorsRequest.onload = function () {
-      if (contributorsRequest.status != 200) {
-        document.querySelector("#contributors").innerHTML = "multiple";
-        return;
-      }
-
-      try {
-        var response = JSON.parse(contributorsRequest.response);
-
-        numberOfContributors += response.length;
-
-        if (response.length < 100) {
-          document.querySelector("#contributors").innerHTML =
-            numberOfContributors;
-        } else {
-          currentPage++;
-          getContributors();
+        if (contributorsRequest.status != 200) {
+            document.querySelector("#contributors").innerHTML = "multiple";
+            return;
         }
-      } catch {
-        document.querySelector("#contributors").innerHTML = "multiple";
-      }
+
+        try {
+            let header = contributorsRequest.getResponseHeader("link");
+            let contributors = header.match(/page=(\d+)>; rel=\"last\"/)[1]
+            document.querySelector("#contributors").innerHTML = contributors;
+        } catch {
+            document.querySelector("#contributors").innerHTML = "multiple";
+        }
     };
 
     contributorsRequest.onerror = function () {
-      document.querySelector("#contributors").innerHTML = "multiple";
+        document.querySelector("#contributors").innerHTML = "multiple";
     };
-  }
-
-  getContributors();
 });


### PR DESCRIPTION
## What changed and why?

   Improve contributors.js to only doing a single fetch to get the contributor count.

## Checklist

   <!-- 
   Each - [ ] below is a checkbox that will show up on the PR.
   Either add an X inside the [X], or submit the PR and click the checkboxes.
   -->

- [x] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work

