### PR TITLE
Correct wrong Python string fields

### DIFF
--- a/web/thesauruses/python/3/strings.json
+++ b/web/thesauruses/python/3/strings.json
@@ -16,7 +16,7 @@
     },
     "default_string_byte_encoding": {
       "name": "Default byte encoding (ex: ASCII UTF-8, UTF-16, etc.)",
-      "not-implemented": true
+      "code": "UTF-8"
     },
     "create_new_string": {
       "name": "Create new string",
@@ -24,15 +24,15 @@
     },
     "create_multiline_string": {
       "name": "Create new multi-line string",
-      "not-implemented": true
+      "code": "example = \"\"\"New\nMulti-line\nString\n\"\"\""
     },
     "assign_new_string": {
       "name": "Assign string from another string",
-      "not-implemented": true
+      "code": "example = \"New String Example\"\nanother = example"
     },
     "destroy_string": {
       "name": "Destroy string",
-      "not-implemented": true
+      "code": "del example"
     },
     "length_of_string": {
       "name": "Length of string",
@@ -44,7 +44,7 @@
     },
     "clear_string": {
       "name": "Clear/empty string",
-      "not-implemented": true
+      "code": "example = \"\""
     },
     "is_empty": {
       "name": "Is string empty?",


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Resolves #590


## What changed and why?

LOC: 19, 27, 31, 35, and 47.

Corrects missing or incorrect info on Python strings. LOC 35 is a bit of a sledgehammer as it deletes the _object_ itself, but incidentally also destroys the string in the process.

## Checklist

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work

## Any additional comments or things to be aware of while reviewing?

Have URLs for source material, but looked at the rest of the examples and none of them had embedded links for non-code answers so `¯\_(ツ)_/¯`

