### PR TITLE
[JS] Added missing data types concept for ECMAScript 2009 and 2023

### DIFF
--- a/web/thesauruses/javascript/ECMAScript 2009/data_types.json
+++ b/web/thesauruses/javascript/ECMAScript 2009/data_types.json
@@ -1,0 +1,116 @@
+{
+  "meta": {
+    "language": "javascript",
+    "language_version": "ECMAScript 2009",
+    "language_name": "JavaScript",
+    "structure": "data_types"
+  },
+  "concepts": {
+    "boolean": {
+      "code": "Boolean",
+      "comment": "The type is an object wrapper for the boolean primitive data type",
+      "name": "Boolean"
+    },
+    "signed_integer_8_bit": {
+      "not-implemented": true,
+      "name": "Signed 8-bit integer"
+    },
+    "unsigned_integer_8_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 8-bit integer"
+    },
+    "signed_integer_16_bit": {
+      "not-implemented": true,
+      "name": "Signed 16-bit integer"
+    },
+    "unsigned_integer_16_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 16-bit integer"
+    },
+    "signed_integer_32_bit": {
+      "not-implemented": true,
+      "name": "Signed 32-bit integer"
+    },
+    "unsigned_integer_32_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 32-bit integer"
+    },
+    "signed_integer_64_bit": {
+      "not-implemented": true,
+      "name": "Signed 64-bit integer"
+    },
+    "unsigned_integer_64_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 64-bit integer"
+    },
+    "signed_integer_as_object": {
+      "code": "BigInt",
+      "comment": "The type is an object wrapper for the bigint primitive data type",
+      "name": "Signed object-based Integer"
+    },
+    "unsigned_integer_as_object": {
+      "not-implemented": true,
+      "name": "Unsigned object-based Integer"
+    },
+    "signed_float_16_bit": {
+      "not-implemented": true,
+      "name": "Signed 16-bit floating point"
+    },
+    "unsigned_float_16_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 16-bit floating point"
+    },
+    "signed_float_32_bit": {
+      "not-implemented": true,
+      "name": "Signed 32-bit floating point"
+    },
+    "unsigned_float_32_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 32-bit floating point"
+    },
+    "signed_float_64_bit": {
+      "code": "Number",
+      "comment": "The Number wrapper object is represented by a double-precision 64-bit float under the hood. All the 'Not-a-Number' values in the IEEE Standard specification are clubbed into a single special NaN value in javascript.",
+      "name": "Signed 64-bit floating point"
+    },
+    "unsigned_float_64_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 64-bit floating point"
+    },
+    "signed_float_as_object": {
+      "code": "Number",
+      "comment": "The type is an object wrapper for the number primitive data type",
+      "name": "Signed object-based floating point"
+    },
+    "unsigned_float_as_object": {
+      "not-implemented": true,
+      "name": "Unsigned object-based floating point"
+    },
+    "character": {
+      "not-implemented": true,
+      "name": "Character"
+    },
+    "string_as_object": {
+      "code": "String",
+      "comment": "The type is an object wrapper for the string primitive data type",
+      "name": "String as an object"
+    },
+    "string_as_array": {
+      "code": "String",
+      "comment": "String is implemented as a set of ordered sequences of zero or more 16-bit unsigned integer values (each treated as UTF-16 code unit). String objects support [index] notation to dereference characters, but do not support the full spectrum of array methods",
+      "name": "String as an array of characters"
+    },
+    "complex_as_object": {
+      "not-implemented": true,
+      "name": "Complex Number as an object"
+    },
+    "real_number_part": {
+      "not-implemented": true,
+      "name": "Complex number real part"
+    },
+    "imaginary_number_part": {
+      "not-implemented": true,
+      "name": "Complex number imaginary part"
+    }
+  }
+}

--- a/web/thesauruses/javascript/ECMAScript 2023/data_types.json
+++ b/web/thesauruses/javascript/ECMAScript 2023/data_types.json
@@ -1,0 +1,116 @@
+{
+  "meta": {
+    "language": "javascript",
+    "language_version": "ECMAScript 2023",
+    "language_name": "JavaScript",
+    "structure": "data_types"
+  },
+  "concepts": {
+    "boolean": {
+      "code": "Boolean",
+      "comment": "The type is an object wrapper for the boolean primitive data type",
+      "name": "Boolean"
+    },
+    "signed_integer_8_bit": {
+      "not-implemented": true,
+      "name": "Signed 8-bit integer"
+    },
+    "unsigned_integer_8_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 8-bit integer"
+    },
+    "signed_integer_16_bit": {
+      "not-implemented": true,
+      "name": "Signed 16-bit integer"
+    },
+    "unsigned_integer_16_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 16-bit integer"
+    },
+    "signed_integer_32_bit": {
+      "not-implemented": true,
+      "name": "Signed 32-bit integer"
+    },
+    "unsigned_integer_32_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 32-bit integer"
+    },
+    "signed_integer_64_bit": {
+      "not-implemented": true,
+      "name": "Signed 64-bit integer"
+    },
+    "unsigned_integer_64_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 64-bit integer"
+    },
+    "signed_integer_as_object": {
+      "code": "BigInt",
+      "comment": "The type is an object wrapper for the bigint primitive data type",
+      "name": "Signed object-based Integer"
+    },
+    "unsigned_integer_as_object": {
+      "not-implemented": true,
+      "name": "Unsigned object-based Integer"
+    },
+    "signed_float_16_bit": {
+      "not-implemented": true,
+      "name": "Signed 16-bit floating point"
+    },
+    "unsigned_float_16_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 16-bit floating point"
+    },
+    "signed_float_32_bit": {
+      "not-implemented": true,
+      "name": "Signed 32-bit floating point"
+    },
+    "unsigned_float_32_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 32-bit floating point"
+    },
+    "signed_float_64_bit": {
+      "code": "Number",
+      "comment": "The Number wrapper object is represented by a double-precision 64-bit float under the hood. All the 'Not-a-Number' values in the IEEE Standard specification are clubbed into a single special NaN value in javascript.",
+      "name": "Signed 64-bit floating point"
+    },
+    "unsigned_float_64_bit": {
+      "not-implemented": true,
+      "name": "Unsigned 64-bit floating point"
+    },
+    "signed_float_as_object": {
+      "code": "Number",
+      "comment": "The type is an object wrapper for the number primitive data type",
+      "name": "Signed object-based floating point"
+    },
+    "unsigned_float_as_object": {
+      "not-implemented": true,
+      "name": "Unsigned object-based floating point"
+    },
+    "character": {
+      "not-implemented": true,
+      "name": "Character"
+    },
+    "string_as_object": {
+      "code": "String",
+      "comment": "The type is an object wrapper for the string primitive data type",
+      "name": "String as an object"
+    },
+    "string_as_array": {
+      "code": "String",
+      "comment": "String is implemented as a set of ordered sequences of zero or more 16-bit unsigned integer values (each treated as UTF-16 code unit). String objects support [index] notation to dereference characters, but do not support the full spectrum of array methods",
+      "name": "String as an array of characters"
+    },
+    "complex_as_object": {
+      "not-implemented": true,
+      "name": "Complex Number as an object"
+    },
+    "real_number_part": {
+      "not-implemented": true,
+      "name": "Complex number real part"
+    },
+    "imaginary_number_part": {
+      "not-implemented": true,
+      "name": "Complex number imaginary part"
+    }
+  }
+}


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Part of issue #609 


## What changed and why?

Added data types concept files from ECMAScript 2021 (which already exists in the current version of codethesaur.us) to ECMAScript 2009 and ECMAScript 2023.

## Checklist

- [ ] I claimed any associated issue(s) and they are not someone else's
- [x] I have looked at documentation to ensure I made any revisions correctly
- [x] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

The same thing may be done for the other missing concepts for ECMAScript 2009 and ECMAScript 2023.