### PR TITLE
Added missing C# logical and bitwise operators

### DIFF
--- a/web/thesauruses/csharp/9/operators.json
+++ b/web/thesauruses/csharp/9/operators.json
@@ -122,6 +122,18 @@
       "not-implemented": "true",
       "name": "Is not operator"
     },
+    "logical_and": {
+      "code": "&&",
+      "name": "Logical AND Operator"
+    },
+    "logical_or": {
+      "code": "||",
+      "name": "Logical OR Operator"
+    },
+    "logical_not": {
+      "code": "!",
+      "name": "Logical NOT Operator"
+    },
     "left_shift": {
       "code": "<<",
       "name": "Left shift bitwise operator"

--- a/web/thesauruses/csharp/9/operators.json
+++ b/web/thesauruses/csharp/9/operators.json
@@ -134,6 +134,30 @@
       "code": "!",
       "name": "Logical NOT Operator"
     },
+    "bitwise_and": {
+      "code": "&",
+      "name": "Bitwise AND operator"
+    },
+    "bitwise_and_assignmnet": {
+      "code": "&=",
+      "name": "Bitwise AND and assignment operator"
+    },
+    "bitwise_or": {
+      "code": "|",
+      "name": "Bitwise OR operator"
+    },
+    "bitwise_or_assignment": {
+      "code": "|=",
+      "name": "Bitwise OR and assignment operator"
+    },
+    "bitwise_not": {
+      "code": "~",
+      "name": "Bitwise NOT operator"
+    },
+    "bitwise_xor": {
+      "code": "^",
+      "name": "Bitwise XOR operator"
+    },
     "left_shift": {
       "code": "<<",
       "name": "Left shift bitwise operator"


### PR DESCRIPTION
<!--
Hello! Thank you for contributing to Code Thesaurus!

This template can help you fill out a pull request with all the information 
needed to review it. The text between these exclamation tags are comments 
and won't show up on the pull request. The text after ## are headers. Please
leave the headers unless otherwise noted and follow the instructions to 
fill out each section with as much information as you can to assist the 
reviewer!
-->


## What GitHub issue does this PR apply to?

Part of issue https://github.com/codethesaurus/codethesaur.us/issues/603


## What changed and why?

Added missing C# logical operators to the C# operators json. They were missing.



## Checklist

- [ ] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work


## Any additional comments or things to be aware of while reviewing?

   Do not merge yet. I am yet to fix the bitwise operators, just didn't have the time. 

