### PR TITLE
Adjusted line indentation in operands.json in JS thesauruses

### DIFF
--- a/web/thesauruses/csharp/9/operators.json
+++ b/web/thesauruses/csharp/9/operators.json
@@ -122,6 +122,18 @@
       "not-implemented": "true",
       "name": "Is not operator"
     },
+    "logical_and": {
+      "code": "&&",
+      "name": "Logical AND Operator"
+    },
+    "logical_or": {
+      "code": "||",
+      "name": "Logical OR Operator"
+    },
+    "logical_not": {
+      "code": "!",
+      "name": "Logical NOT Operator"
+    },
     "left_shift": {
       "code": "<<",
       "name": "Left shift bitwise operator"

--- a/web/thesauruses/csharp/9/operators.json
+++ b/web/thesauruses/csharp/9/operators.json
@@ -134,6 +134,30 @@
       "code": "!",
       "name": "Logical NOT Operator"
     },
+    "bitwise_and": {
+      "code": "&",
+      "name": "Bitwise AND operator"
+    },
+    "bitwise_and_assignmnet": {
+      "code": "&=",
+      "name": "Bitwise AND and assignment operator"
+    },
+    "bitwise_or": {
+      "code": "|",
+      "name": "Bitwise OR operator"
+    },
+    "bitwise_or_assignment": {
+      "code": "|=",
+      "name": "Bitwise OR and assignment operator"
+    },
+    "bitwise_not": {
+      "code": "~",
+      "name": "Bitwise NOT operator"
+    },
+    "bitwise_xor": {
+      "code": "^",
+      "name": "Bitwise XOR operator"
+    },
     "left_shift": {
       "code": "<<",
       "name": "Left shift bitwise operator"

--- a/web/thesauruses/javascript/ECMAScript 2020/operators.json
+++ b/web/thesauruses/javascript/ECMAScript 2020/operators.json
@@ -55,13 +55,13 @@
       "name": "Modulus and assignment operator"
     },
     "unary_plus": {
-      "code" : "+operand",
-      "name" : "Unary plus operator"
-  },
+      "code": "+operand",
+      "name": "Unary plus operator"
+    },
     "unary_minus": {
-      "code" : "-operand",
-      "name" : "Unary minus operator"
-  },
+      "code": "-operand",
+      "name": "Unary minus operator"
+    },
     "increment": {
       "code": "++operand or operand++",
       "name": "Increment (add 1) operator"
@@ -125,57 +125,57 @@
       "name": "Is not operator"
     },
     "logical_and": {
-      "code" : "expression1 && expression2",
-      "name" : "Logical AND Operator"
-  },
+      "code": "expression1 && expression2",
+      "name": "Logical AND Operator"
+    },
     "logical_or": {
-      "code" : "expression1 || expression2",
-      "name" : "Logical OR Operator"
-  },
-  "logical_not": {
-      "code" : "!expression",
-      "name" : "Logical NOT Operator"
-  },
-"bitwise_and": {
-      "code" : "operand1 & operand2",
-      "name" : "Bitwise AND operator"
-  },
-"bitwise_and_assignmnet": {
-      "code" : "result &= operand1",
-      "name" : "Bitwise AND and assignment operator"
-  },
-"bitwise_or": {
-      "code" : "operand1 | operand2",
-      "name" : "Bitwise OR operator"
-  },
-"bitwise_or_assignment": {
-      "code" : "result |= operand1",
-      "name" : "Bitwise OR and assignment operator"
-  },
-"bitwise_not": {
-      "code" : "~operand",
-      "name" : "Bitwise NOT operator"
-  },
+      "code": "expression1 || expression2",
+      "name": "Logical OR Operator"
+    },
+    "logical_not": {
+      "code": "!expression",
+      "name": "Logical NOT Operator"
+    },
+    "bitwise_and": {
+      "code": "operand1 & operand2",
+      "name": "Bitwise AND operator"
+    },
+    "bitwise_and_assignmnet": {
+      "code": "result &= operand1",
+      "name": "Bitwise AND and assignment operator"
+    },
+    "bitwise_or": {
+      "code": "operand1 | operand2",
+      "name": "Bitwise OR operator"
+    },
+    "bitwise_or_assignment": {
+      "code": "result |= operand1",
+      "name": "Bitwise OR and assignment operator"
+    },
+    "bitwise_not": {
+      "code": "~operand",
+      "name": "Bitwise NOT operator"
+    },
     "bitwise_not_assignment": {
       "not-implemented": "true",
-      "name" : "Bitwise NOT and assignment operator"
-  },
-"bitwise_xor": {
-      "code" : "operand1 ^ operand2",
-      "name" : "Bitwise XOR operator"
-  },
-"bitwise_xor_assignment": {
-      "code" : "result ^= operand1",
-      "name" : "Bitwise XOR and assignment operator"
-  },
+      "name": "Bitwise NOT and assignment operator"
+    },
+    "bitwise_xor": {
+      "code": "operand1 ^ operand2",
+      "name": "Bitwise XOR operator"
+    },
+    "bitwise_xor_assignment": {
+      "code": "result ^= operand1",
+      "name": "Bitwise XOR and assignment operator"
+    },
     "bitwise_xnor": {
       "not-implemented": "true",
-      "name" : "Bitwise XNOR operator"
-  },
+      "name": "Bitwise XNOR operator"
+    },
     "bitwise_xnor_assignment": {
       "not-implemented": "true",
-      "name" : "Bitwise XNOR and assignment operator"
-  },
+      "name": "Bitwise XNOR and assignment operator"
+    },
     "left_shift": {
       "code": "operand1 << value",
       "name": "Left shift bitwise operator"

--- a/web/thesauruses/javascript/ECMAScript 2021/operators.json
+++ b/web/thesauruses/javascript/ECMAScript 2021/operators.json
@@ -55,13 +55,13 @@
       "name": "Modulus and assignment operator"
     },
     "unary_plus": {
-      "code" : "+operand",
-      "name" : "Unary plus operator"
-  },
+      "code": "+operand",
+      "name": "Unary plus operator"
+    },
     "unary_minus": {
-      "code" : "-operand",
-      "name" : "Unary minus operator"
-  },
+      "code": "-operand",
+      "name": "Unary minus operator"
+    },
     "increment": {
       "code": "++operand or operand++",
       "name": "Increment (add 1) operator"
@@ -125,57 +125,57 @@
       "name": "Is not operator"
     },
     "logical_and": {
-      "code" : "expression1 && expression2",
-      "name" : "Logical AND Operator"
-  },
+      "code": "expression1 && expression2",
+      "name": "Logical AND Operator"
+    },
     "logical_or": {
-      "code" : "expression1 || expression2",
-      "name" : "Logical OR Operator"
-  },
-  "logical_not": {
-      "code" : "!expression",
-      "name" : "Logical NOT Operator"
-  },
-"bitwise_and": {
-      "code" : "operand1 & operand2",
-      "name" : "Bitwise AND operator"
-  },
-"bitwise_and_assignmnet": {
-      "code" : "result &= operand1",
-      "name" : "Bitwise AND and assignment operator"
-  },
-"bitwise_or": {
-      "code" : "operand1 | operand2",
-      "name" : "Bitwise OR operator"
-  },
-"bitwise_or_assignment": {
-      "code" : "result |= operand1",
-      "name" : "Bitwise OR and assignment operator"
-  },
-"bitwise_not": {
-      "code" : "~operand",
-      "name" : "Bitwise NOT operator"
-  },
+      "code": "expression1 || expression2",
+      "name": "Logical OR Operator"
+    },
+    "logical_not": {
+      "code": "!expression",
+      "name": "Logical NOT Operator"
+    },
+    "bitwise_and": {
+      "code": "operand1 & operand2",
+      "name": "Bitwise AND operator"
+    },
+    "bitwise_and_assignmnet": {
+      "code": "result &= operand1",
+      "name": "Bitwise AND and assignment operator"
+    },
+    "bitwise_or": {
+      "code": "operand1 | operand2",
+      "name": "Bitwise OR operator"
+    },
+    "bitwise_or_assignment": {
+      "code": "result |= operand1",
+      "name": "Bitwise OR and assignment operator"
+    },
+    "bitwise_not": {
+      "code": "~operand",
+      "name": "Bitwise NOT operator"
+    },
     "bitwise_not_assignment": {
       "not-implemented": "true",
-      "name" : "Bitwise NOT and assignment operator"
-  },
-"bitwise_xor": {
-      "code" : "operand1 ^ operand2",
-      "name" : "Bitwise XOR operator"
-  },
-"bitwise_xor_assignment": {
-      "code" : "result ^= operand1",
-      "name" : "Bitwise XOR and assignment operator"
-  },
+      "name": "Bitwise NOT and assignment operator"
+    },
+    "bitwise_xor": {
+      "code": "operand1 ^ operand2",
+      "name": "Bitwise XOR operator"
+    },
+    "bitwise_xor_assignment": {
+      "code": "result ^= operand1",
+      "name": "Bitwise XOR and assignment operator"
+    },
     "bitwise_xnor": {
       "not-implemented": "true",
-      "name" : "Bitwise XNOR operator"
-  },
+      "name": "Bitwise XNOR operator"
+    },
     "bitwise_xnor_assignment": {
       "not-implemented": "true",
-      "name" : "Bitwise XNOR and assignment operator"
-  },
+      "name": "Bitwise XNOR and assignment operator"
+    },
     "left_shift": {
       "code": "operand1 << value",
       "name": "Left shift bitwise operator"


### PR DESCRIPTION
<!--
Hello! Thank you for contributing to Code Thesaurus!

This template can help you fill out a pull request with all the information 
needed to review it. The text between these exclamation tags are comments 
and won't show up on the pull request. The text after ## are headers. Please
leave the headers unless otherwise noted and follow the instructions to 
fill out each section with as much information as you can to assist the 
reviewer!
-->


## What GitHub issue does this PR apply to?

 <!--
   If you're working on an existing issue, replace "xxxx" below with the issue 
   number. You can change it to say only "Closes #", "Fixes #", or "Resolves #".
   Don't add the word "issue" to it otherwise it won't link correctly.

   If you got here via the edit buttons on the website and/or your changes 
   don't relate to an issue, feel free to delete "Resolves #" and put "None", 
   or note why you chose to make a PR!
   -->

No issue. Simple style formatting


## What changed and why?

  Changed indentation on a couple of json files for better style compliance. 



## Checklist

   <!-- 
   Each - [X] below is a checkbox that will show up on the PR.
   Either add an X inside the [X], or submit the PR and click the checkboxes.
   -->

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

   <!-- Please replace this line with any extra information that's helpful -->

