### PR TITLE
Fix misspelled key name s/bitwise_and_assignmnet/bitwise_and_assignment/

### DIFF
--- a/web/thesauruses/csharp/9/operators.json
+++ b/web/thesauruses/csharp/9/operators.json
@@ -138,7 +138,7 @@
       "code": "&",
       "name": "Bitwise AND operator"
     },
-    "bitwise_and_assignmnet": {
+    "bitwise_and_assignment": {
       "code": "&=",
       "name": "Bitwise AND and assignment operator"
     },

--- a/web/thesauruses/javascript/ECMAScript 2020/operators.json
+++ b/web/thesauruses/javascript/ECMAScript 2020/operators.json
@@ -140,7 +140,7 @@
       "code" : "operand1 & operand2",
       "name" : "Bitwise AND operator"
   },
-"bitwise_and_assignmnet": {
+"bitwise_and_assignment": {
       "code" : "result &= operand1",
       "name" : "Bitwise AND and assignment operator"
   },

--- a/web/thesauruses/javascript/ECMAScript 2021/operators.json
+++ b/web/thesauruses/javascript/ECMAScript 2021/operators.json
@@ -140,7 +140,7 @@
       "code" : "operand1 & operand2",
       "name" : "Bitwise AND operator"
   },
-"bitwise_and_assignmnet": {
+"bitwise_and_assignment": {
       "code" : "result &= operand1",
       "name" : "Bitwise AND and assignment operator"
   },


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Resolves #638


## What changed and why?

Rename keys so these rows are correctly rendered

## (If editing Django app) Please add screenshots


## Checklist

   <!-- 
   Each - [ ] below is a checkbox that will show up on the PR.
   Either add an X inside the [X], or submit the PR and click the checkboxes.
   -->

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] (If editing Django) I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

   <!-- Please replace this line with any extra information that's helpful -->

