### PR TITLE
Fix: Show friendly 500.html when database is unavailable

### DIFF
--- a/codethesaurus/settings.py
+++ b/codethesaurus/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'web.middleware.DatabaseDownMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -1,0 +1,18 @@
+# web/middleware.py
+from django.db.utils import OperationalError
+from django.shortcuts import render
+from django.http import HttpResponseServerError
+
+class DatabaseDownMiddleware:
+    """
+    Catch database OperationalError and show custom 500 error page.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            return self.get_response(request)
+        except OperationalError:
+            # Render error500.html template
+            return HttpResponseServerError(render(request, "error500.html"))

--- a/web/templates/error500.html
+++ b/web/templates/error500.html
@@ -4,9 +4,11 @@
 
 <div class="container">
   <div class="bg-light p-5 rounded">
-    <h1>500 Error - Server Error!</h1>
+    <!-- <h1>500 Error - Server Error!</h1>
     <p class="lead">I don't know what went wrong, but the code broke!</p>
-    <a class="btn btn-lg btn-primary" href="/" role="button">Go to the Home Page &raquo;</a>
+    <a class="btn btn-lg btn-primary" href="/" role="button">Go to the Home Page &raquo;</a> -->
+    <h1>We’ll be back soon!</h1>
+    <p>The site is temporarily down due to maintenance. Please try again shortly.</p>
   </div>
 </div>
 


### PR DESCRIPTION
<!--
Hello! Thank you for contributing to Code Thesaurus!

This template can help you fill out a pull request with all the information 
needed to review it. The text between these exclamation tags are comments 
and won't show up on the pull request. The text after ## are headers. Please
leave the headers unless otherwise noted and follow the instructions to 
fill out each section with as much information as you can to assist the 
reviewer!
-->


## What GitHub issue does this PR apply to?

 <!--
   If you're working on an existing issue, replace "xxxx" below with the issue 
   number. You can change it to say only "Closes #123", "Fixes #123", or "Resolves #123".
   Don't add the word "issue" to it otherwise it won't link correctly.

   If you got here via the edit buttons on the website and/or your changes 
   don't relate to an issue, feel free to delete "Resolves #" and put "None", 
   or note why you chose to make a PR.
   -->

Resolves #776 


## What changed and why?

This PR improves error handling when the database is unavailable.  
Previously, users would see the default Django error output, which exposed technical details and was not user-friendly.  
### Changes made:
1. **Created `DatabaseDownMiddleware`** in `web/middleware.py`  
   - Intercepts database errors and ensures users are redirected to a custom error page.  

2. **Registered the middleware** in `settings.py`  
   - Added:  
     ```python
     'web.middleware.DatabaseDownMiddleware'
     ```  

3. **Updated `error500.html` page** in the templates directory  
   - Shows a clear and user-friendly message:  
     *“The site is temporarily down, please try again later.”*  

This ensures users see a consistent and friendly downtime page instead of a raw Django traceback.  

## (If editing website code) Please add screenshots

   <!--
   If this doesn't apply, you can delete this header and section.
   If it's applicable, please copy screenshots, then paste them below.
   GitHub will paste images as a line of text as: ![image](url)
   You can preview it with the "Preview" button above.
   -->

### Add a file web/middleware.py for catching database operational error:
![image](https://github.com/user-attachments/assets/8bf97ba2-174c-4c18-8cfe-ccda95113bce)

### Add the DatabasedownMiddleware from middleware.py to MIDDLEWARE in setting.py
![image](https://github.com/user-attachments/assets/c3c41f12-054f-4a35-a60e-72a84d66c8cd)

### Message change in error500.html:
![image](https://github.com/user-attachments/assets/4a3c0258-756d-4f26-b237-4a65b6928b1e)

### Finally, this is how It will look like: 
![image](https://github.com/user-attachments/assets/c8c5d22d-cadf-4488-a7fc-7463d6b88524) 

## Checklist

   <!-- 
   Each - [ ] below is a checkbox that will show up on the PR.
   Either add an X inside the [X], or submit the PR and click the checkboxes.
   If you couldn't test something, leave a comment at the bottom and explain why.
   -->

- [X] I claimed any associated issue(s) and they are not someone else's
- [X] I have looked at documentation to ensure I made any revisions correctly
- [X] I tested my changes locally to ensure they work
- [ ] For language files, I have validated the edited files are valid JSON and data shows up correctly
- [ ] For website code edits, I have added or edited any appropriate unit tests for my changes


## Any additional comments or things to be aware of while reviewing?

   <!-- If applicable, please replace this line with any extra information that's helpful -->

To test this change locally, please ensure the following settings are applied in `settings.py`:

```python
DEBUG = False
SECURE_SSL_REDIRECT = False

```
- **DEBUG = False** → Required because custom error pages (error500.html) only render when Django is not in debug mode. With DEBUG=True, Django displays the default debug traceback instead.

- **SECURE_SSL_REDIRECT = False **→ Disabled so the Django development server doesn’t attempt to force HTTPS (it only supports HTTP locally).


With these settings, when the database connection is unavailable, the updated error500.html page will be shown to users instead of the default Django error response.
